### PR TITLE
🧹 Get resources route working

### DIFF
--- a/app/controllers/hyku_knapsack/pages_controller.rb
+++ b/app/controllers/hyku_knapsack/pages_controller.rb
@@ -1,0 +1,4 @@
+module HykuKnapsack
+  class PagesController < ::Hyrax::PagesController
+  end
+end

--- a/app/models/content_block_decorator.rb
+++ b/app/models/content_block_decorator.rb
@@ -1,19 +1,33 @@
 # frozen_string_literal: true
 
 module ContentBlockDecorator
-  NAME_REGISTRY = {
-    marketing: :marketing_text,
-    researcher: :featured_researcher,
-    announcement: :announcement_text,
-    about: :about_page,
-    help: :help_page,
-    terms: :terms_page,
-    agreement: :agreement_page,
-    home_text: :home_text,
-    resources: :resources_page,
-    homepage_about_section_heading: :homepage_about_section_heading,
-    homepage_about_section_content: :homepage_about_section_content
-  }.freeze
+  def for(key)
+    key = key.respond_to?(:to_sym) ? key.to_sym : key
+    raise ArgumentError, "#{key} is not a ContentBlock name" unless registered?(key)
+    # Override to refer to .name_registry instead of NAME_REGISTRY
+    ContentBlock.public_send(name_registry[key])
+  end
+
+  # Adding a utility method to check if a key is registered
+  # TODO: Add something like this to Hyku?  It would basically return NAME_REGISTRY
+  #       then in a decorator we can override and call super.merge(foo: :bar)
+  def name_registry
+    ContentBlock::NAME_REGISTRY.dup.merge(resources: :resources_page)
+  end
+
+  # Override to refer to .name_registry instead of NAME_REGISTRY
+  def registered?(key)
+    name_registry.include?(key)
+  end
+
+  # ADL specifc methods
+  def resources_page
+    find_or_create_by(name: 'resources_page')
+  end
+
+  def resources_page=(value)
+    resources_page.update(value: value)
+  end
 end
 
-ContentBlock.prepend(ContentBlockDecorator)
+ContentBlock.singleton_class.prepend(ContentBlockDecorator)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 HykuKnapsack::Engine.routes.draw do
-  get 'resources' => 'hyrax/pages#show', key: 'resources'
+  get 'resources' => 'pages#show', key: 'resources'
 end


### PR DESCRIPTION
This commit will get the resources route working. It will also add a HykuKnapsack::PagesController which inherits from Hyrax::PagesController so the route won't throw a namespace error.  Further down the line, we needed to decorate the ContentBlock model to add the resources key.  I am doing this with no change to Hyku although we may want to add the `#name_registry` method to Hyku as a convenience for overrides since we can't add to a frozen hash.

ref: https://github.com/scientist-softserv/adventist-dl/issues/556

# Notes

This gets the /resources route to load but there are problems in erb files down the line that are currently being addressed.  In an effort to not step on toes and letting the scope of this PR get too big, I am stopping here.