### PR TITLE
Show actions

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -11,6 +11,7 @@
     <div class="panel panel-default">
       <div class="panel-heading">
         <%= render 'work_title', presenter: @presenter %>
+        <%= render 'show_actions', presenter: @presenter %> 
       </div>
       <div class="panel-body">
         <div class="row">

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -6,13 +6,19 @@
 <%= render './shared/additional_citations' %>
 <div class="row work-type">
 <%# OVERRIDE Hyrax 2.9.1 here to hide the work type H1 title on all show-work pages %>
-  <div class="col-xs-12">&nbsp;</div>
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <%= render 'work_title', presenter: @presenter %>
-        <%= render 'show_actions', presenter: @presenter %> 
-      </div>
+        <div class="row">
+          <div class="col-sm-8">
+            <%= render 'work_title', presenter: @presenter %>
+          </div>
+          <div class="col-sm-4 text-right">
+            <div class="show-actions">
+              <%= render 'show_actions', presenter: @presenter %>
+            </div>
+          </div>
+        </div>
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>


### PR DESCRIPTION
# Story

Refs [#572
](https://github.com/scientist-softserv/adventist-dl/issues/572)

# Expected Behavior Before Changes

Work show page did not include action buttons

# Expected Behavior After Changes

Buttons appear and are right-justified, as they previously were. (Note that for styling to match, it would need to include https://github.com/scientist-softserv/adventist_knapsack/pull/20

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-10-02 at 11 58 17 PM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/2c3d0cbd-e649-4a32-8b8f-d06f69e3b994)

</details>

# Notes