### PR TITLE
🧹 Specify submodule branch for hyrax-webapp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "hyrax-webapp"]
 	path = hyrax-webapp
 	url = https://github.com/samvera/hyku.git
+	branch = adventist_dev


### PR DESCRIPTION
In discussion with the team, we're to be using that branch.  This change does two things:

1. Points to the latest commit on that branch.
2. Specifies the branch we're using.

At somepoint, we'll want to move away from the branch to reference "main" but that's a day on the hopefully near horizon.
