### PR TITLE
Load view paths on display

### DIFF
--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -50,5 +50,14 @@
     </div><!-- /#content-wrapper -->
     <%= render partial: 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
+
+    <footer>
+  <p>View Paths:</p>
+  <ul>
+    <% view_paths.each do |path| %>
+<li><%= path %></li>
+    <% end %>
+  </ul>
+</footer>
   </body>
 </html>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -50,14 +50,5 @@
     </div><!-- /#content-wrapper -->
     <%= render partial: 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
-
-    <footer>
-  <p>View Paths:</p>
-  <ul>
-    <% view_paths.each do |path| %>
-<li><%= path %></li>
-    <% end %>
-  </ul>
-</footer>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -37,4 +37,12 @@
       </div>
     </div>
   </div>
+  <div style="display:none;">
+    <p>View Paths:</p>
+    <ul>
+      <% view_paths.each do |path| %>
+        <li><%= path %></li>
+      <% end %>
+    </ul>
+  </div>
 </footer>

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -34,15 +34,17 @@ module HykuKnapsack
       Dir.glob(File.join(my_engine_root, "lib/**/*_decorator*.rb")).sort.each do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+
+      # Hyku::Application.theme_view_path_roots.push HykuKnapsack::Engine.root
     end
 
     config.after_initialize do
       my_engine_root = HykuKnapsack::Engine.root.to_s
-      paths = ActionController::Base.view_paths.collect(&:to_s)
+      paths = ::ApplicationController.view_paths.collect(&:to_s)
       # This is the opposite of what you usually want to do. Normally app views override engine views
       # but in our case things in the Knapsack override what is in the application
       paths = [my_engine_root + '/app/views'] + paths
-      ActionController::Base.view_paths = paths.uniq
+      ::ApplicationController.view_paths = paths.uniq
       ::ApplicationController.send :helper, HykuKnapsack::Engine.helpers
 
       # Moves the Dog Biscuits locales to the end of the load path

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -40,11 +40,22 @@ module HykuKnapsack
 
     config.after_initialize do
       my_engine_root = HykuKnapsack::Engine.root.to_s
-      paths = ::ApplicationController.view_paths.collect(&:to_s)
-      # This is the opposite of what you usually want to do. Normally app views override engine views
-      # but in our case things in the Knapsack override what is in the application
-      paths = [my_engine_root + '/app/views'] + paths
-      ::ApplicationController.view_paths = paths.uniq
+      # This is the opposite of what you usually want to do.  Normally app views override engine
+      # views but in our case things in the Knapsack override what is in the application.
+      # Furthermore we need to account for when the ApplicationController and it's descendants set
+      # their individual view_paths.  By looping through all descendants, we ensure that we have
+      # the Knapsack views at the beginning of the list of view_paths.
+      #
+      # In the load sequence, when we load ApplicationController, we establish the view_path for all
+      # future descendants.  When we then encounter a descendant, we copy the
+      # ApplicationController's view_path to the descendant; then later after we've encountered most
+      # all of the descendants we updated the ApplicationController's view_path, but that does not
+      # propogate to the descendants' copied view_path.
+      ([::ApplicationController] + ::ApplicationController.descendants).each do |klass|
+        paths = klass.view_paths.collect(&:to_s)
+        paths = [my_engine_root + '/app/views'] + paths
+        klass.view_paths = paths.uniq
+      end
       ::ApplicationController.send :helper, HykuKnapsack::Engine.helpers
 
       # Moves the Dog Biscuits locales to the end of the load path


### PR DESCRIPTION
We are discovering that view paths are not consistent across different controllers.  Prior to this PR, for some of the controllers, we had a view path of:

- `/app/samvera/app/views/`
- `/app/samvera/hyrax-webapp/app/views/`

And for others, in particularly the Works controllers, we had:

- `/app/samvera/hyrax-webapp/app/views/`
- `/app/samvera/app/views/`

With this commit, we're taking a hammer to the view paths to mash them into shape.