### PR TITLE
⚙️ Install tesseract eng_best

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,17 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-web
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
+
+# Ensure root permissions for installing Tesseract data
+USER root
+
+# Install "best" training data for Tesseract
+RUN echo "📚 Installing Tesseract Best (training data)!" && \
+    wget https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata -O /usr/share/tessdata/eng_best.traineddata
+
+# Switch back to the non-root user for running the application
+USER app
+
 CMD ./bin/web
 
 FROM hyku-web as hyku-worker

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -103,6 +103,7 @@ require "iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter"
 # Adventist wants to reduce storage size of their split pages; JPGs are a reasonable storage size
 # compared to TIFFs
 DerivativeRodeo::Generators::PdfSplitGenerator.output_extension = 'jpg'
+DerivativeRodeo::Generators::HocrGenerator.additional_tessearct_options = IiifPrint.config.additional_tesseract_options 
 
 ####################################################################################################
 # The DerivativeRodeo is responsible for finding, moving, and/or generating files from various


### PR DESCRIPTION
Adds tesseract eng_best installation instructions to the Dockerfile. Not doing so was the reason the CreateDerivativesJobs would fail.

Issue:
- https://github.com/scientist-softserv/adventist-dl/issues/581

Before this PR end_best.traineddata did not exists in /usr/shared/tessdata

![image](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/af00ef28-c2f3-4481-9e74-3eaee0ba9368)
