### PR TITLE
🧹 Fix spec/features/spash_spec.rb

### DIFF
--- a/spec/features/splash_spec.rb
+++ b/spec/features/splash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "The splash page", multitenant: true do
+RSpec.describe "The splash page", type: :feature, clean: true, multitenant: true do
   around do |example|
     default_host = Capybara.default_host
     Capybara.default_host = Capybara.app_host || "http://#{Account.admin_host}"
@@ -8,14 +8,13 @@ RSpec.describe "The splash page", multitenant: true do
     Capybara.default_host = default_host
   end
 
-  xit "shows the page, displaying the Hyku version" do
+  it "shows the page, displaying the Adventist copyright" do
     visit '/'
-    expect(page).to have_link 'Login to get started', href: main_app.new_user_session_path(locale: 'en')
 
     within 'footer' do
       expect(page).to have_link 'Administrator login'
     end
 
-    expect(page).to have_content("© Adventist Digital Library 2021")
+    expect(page).to have_content("© Adventist Digital Library 2022")
   end
 end


### PR DESCRIPTION
Prior to this commit the diff was as follows:

```
❯ diff spec/features/splash_spec.rb hyrax-webapp/spec/features/splash_spec.rb
3c3,4
< RSpec.describe "The splash page", multitenant: true do
---
> # NOTE: If want to run spec in broweser, you have to set "js: true"
> RSpec.describe "The splash page", type: :feature, clean: true, multitenant: true do
4a6,7
>     original = ENV['HYKU_ADMIN_ONLY_TENANT_CREATION']
>     ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = "true"
8a12
>     ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = original
11c15
<   xit "shows the page, displaying the Hyku version" do
---
>   it "shows the page, displaying the Hyku version" do
19c23
<     expect(page).to have_content("© Adventist Digital Library 2021")
---
>     expect(page).to have_content("Hyku v#{Hyku::VERSION}")
```

After this commit, we've removed the xit and carried forward the directives from Hyku's spec helper:

```
❯ diff spec/features/splash_spec.rb hyrax-webapp/spec/features/splash_spec.rb
2a3
> # NOTE: If want to run spec in broweser, you have to set "js: true"
4a6,7
>     original = ENV['HYKU_ADMIN_ONLY_TENANT_CREATION']
>     ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = "true"
8a12
>     ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = original
11c15
<   it "shows the page, displaying the Adventist copyright" do
---
>   it "shows the page, displaying the Hyku version" do
12a17
>     expect(page).to have_link 'Login to get started', href: main_app.new_user_session_path(locale: 'en')
18c23
<     expect(page).to have_content("© Adventist Digital Library 2022")
---
>     expect(page).to have_content("Hyku v#{Hyku::VERSION}")
```

I have removed a test for a link to "Login to get started" as that is not part of the feature.  The main purpose of the spec is to ensure that we're rendering the correct footer.

Related to:

- - https://github.com/scientist-softserv/adventist-dl/issues/538
