### PR TITLE
🧹 Rename image_form_spec to reflect decoration

### DIFF
--- a/spec/forms/hyrax/image_form_decorator_spec.rb
+++ b/spec/forms/hyrax/image_form_decorator_spec.rb
@@ -1,29 +1,6 @@
 # frozen_string_literal: true
 
-# Generated via
-# `rails generate hyrax:work Image`
-
 RSpec.describe Hyrax::ImageForm do
-  let(:work) { Image.new }
-  let(:form) { described_class.new(work, nil, nil) }
-  let(:file_set) { FactoryBot.create(:file_set) }
-
-  describe ".model_attributes" do
-    subject { described_class.model_attributes(params) }
-
-    let(:params) { ActionController::Parameters.new(attributes) }
-    let(:attributes) do
-      {
-        title: ['foo'],
-        extent: ['extent']
-      }
-    end
-
-    it 'permits parameters' do
-      expect(subject['extent']).to eq ['extent']
-    end
-  end
-
   describe '.terms' do
     it 'returns an array of inherited and custom terms' do
       expect(described_class.terms.sort).to eq(
@@ -37,10 +14,9 @@ RSpec.describe Hyrax::ImageForm do
           visibility ordered_member_ids source in_works_ids member_of_collection_ids
           admin_set_id resource_type extent aark_id part_of place_of_publication
           date_issued alt bibliographic_citation remote_url
+          access_right alternative_title rights_notes
         ].sort
       )
     end
   end
-
-  include_examples("work_form")
 end


### PR DESCRIPTION
Prior to this commit the Knapsace image_form_spec had a test for terms
that was not part of the Hyku.  We introduce these differences through our
decoration in ./app/forms/hyrax/image_form_decorator.rb

To reflect the existence of the decorator and not have a duplicate file
that future us would need to synchronize with Hyku, I've moved the file
and winnowed it down to reflect the specific changes.

I also needed to add three new properties to the spec as it reflects
upstream changes in Hyku (e.g. `access_right` `alternative_title`
`rights_notes`)

<details>
<summary>Diff of filein Hyku and Knapsack</summary>

```
❯ diff spec/forms/hyrax/image_form_spec.rb hyrax-webapp/spec/forms/hyrax/image_form_spec.rb
27,44d26
<   describe '.terms' do
<     it 'returns an array of inherited and custom terms' do
<       expect(described_class.terms.sort).to eq(
<         %i[
<           title creator contributor description keyword abstract
<           license rights_statement publisher date_created
<           subject language identifier based_near related_url
<           representative_id thumbnail_id rendering_ids files
<           visibility_during_embargo embargo_release_date visibility_after_embargo
<           visibility_during_lease lease_expiration_date visibility_after_lease
<           visibility ordered_member_ids source in_works_ids member_of_collection_ids
<           admin_set_id resource_type extent aark_id part_of place_of_publication
<           date_issued alt bibliographic_citation remote_url
<         ].sort
<       )
<     end
<   end
<
```
</details>

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/538