### PR TITLE
🧹 Remove spec/models/image_spec.rb

### DIFF
--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe Image do
   describe 'indexer' do
     subject { described_class.indexer }
 
-    it { is_expected.to eq WorkIndexer }
+    it { is_expected.to eq ImageIndexer }
   end
 end


### PR DESCRIPTION
Prior to this commit the diff was as follows:

```
❯ diff spec/models/image_spec.rb hyrax-webapp/spec/models/image_spec.rb
10c10
<     it { is_expected.to eq WorkIndexer }
---
>     it { is_expected.to eq ImageIndexer }
```

When I ran the specs I got the following:

```
Failures:

  1) Image indexer
     Failure/Error: it { is_expected.to eq WorkIndexer }

     NameError:
       uninitialized constant WorkIndexer
     # ./spec/models/image_spec.rb:10:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./hyrax-webapp/spec/support/multitenancy_metadata.rb:50:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./spec/spec_helper.rb:10:in `block (2 levels) in <top (required)>'

Top 1 slowest examples (0.01817 seconds, 5.4% of total time):
  Image indexer
    0.01817 seconds ./spec/models/image_spec.rb:10

Finished in 0.33691 seconds (files took 13.55 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/models/image_spec.rb:10 # Image indexer
```

I updated the spec to say `it { is_expected.to eq ImageIndexer }` and
the spec passed.

This resulted in the knapsack version being a duplicate of the hyku
version.  So fairwell duplicate!

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/538