### PR TITLE
🐛 Fix bug regarding assumed default work type

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -4,6 +4,14 @@
 Rails.application.config.after_initialize do
   if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
     Bulkrax.setup do |config|
+      ##
+      # By default this is the first registered curation concern.  But based on tests and past
+      # configs, this should be 'GenericWork'.  Note: The below value could change, but it should be
+      # explicit.
+      #
+      # See https://github.com/samvera/hyku/blob/07fde572f9152d513b13f71cae90dd4fdfbfba6c/config/initializers/hyrax.rb#L200-L202
+      config.default_work_type = 'GenericWork'
+
       # Setting the available parsers for Adventist.
       config.parsers = [
         { name: "OAI - Adventist Digital Library", class_name: "Bulkrax::OaiAdventistQdcParser", partial: "oai_adventist_fields" },

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -2,53 +2,16 @@
 
 require "spec_helper"
 
-module Bulkrax
-  module SpecHelper
-    ##
-    # @api private
-    #
-    # A spec helper method for building Bulrax::Entry instances in downstream bulkrax applications.
-    #
-    # @params identifier [#to_s] The identifier of this object
-    # @params data [String] The "data" value for the #raw_metadata of the {Bulkrax::Entry}.
-    # @params parser_class_name [String] One of the the named parsers of {Bulkrax.parsers}
-    # @params entry_class [Class<Bulkrax::Entry>]
-    #
-    # @return [Bulkrax::Entry]
-    #
-    # @todo Extract this method back into a Bulkrax::SpecHelper module.
-    # @todo This could replace some of the factories in Bulkrax's spec suite.
-    # @note This presently assumes as CSV oriented format; or "We haven't checked this against CSV".
-    #       And the signature of this method should be considered volatile.
-    def self.build_csv_entry_for(identifier:, data:, parser_class_name:, entry_class:)
-      import_file_path = Rails.root.join("spec", "fixtures", "csv", "entry.csv")
-      importer = Bulkrax::Importer.new(
-        name: "Test importer for identifier #{identifier}",
-        admin_set_id: "admin_set/default",
-        user_id: 1,
-        limit: 1,
-        parser_klass: parser_class_name,
-        field_mapping: Bulkrax.field_mappings.fetch(parser_class_name),
-        parser_fields: { 'import_file_path' => import_file_path }
-      )
-
-      entry_class.new(
-        importerexporter: importer,
-        identifier: identifier,
-        raw_metadata: data
-      )
-    end
-  end
-end
+require 'bulkrax/entry_spec_helper.rb'
 
 RSpec.describe Bulkrax::CsvEntry do
   describe "#build_metadata" do
     subject(:entry) do
-      Bulkrax::SpecHelper.build_csv_entry_for(
+      Bulkrax::EntrySpecHelper.entry_for(
         data: data,
         identifier: identifier,
         parser_class_name: 'Bulkrax::CsvParser',
-        entry_class: described_class
+        parser_fields: { 'import_file_path' => "spec/fixtures/csv/entry.csv" }
       )
     end
 


### PR DESCRIPTION
This commit includes two things:

1. Favor Bulkrax::EntrySpecHelper provided by Bulkrax (for which the
   removed code was a prototype).
2. Use the existing spec to determine what the default work type should
   be (instead of relying on a random assignment based on the first
   element of the registered curation concerns)

And from this commit, we have a passing test!

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/538
- https://github.com/samvera-labs/bulkrax/pull/726
- https://github.com/samvera-labs/bulkrax/pull/719
- https://github.com/samvera-labs/bulkrax/pull/742
- https://github.com/samvera/hyku/pull/1811