### PR TITLE
🧹 Add Adventist's `TextFileTextExtractionService`

### DIFF
--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -62,6 +62,9 @@ module HykuKnapsack
       Dir[Pathname.new(my_engine_root).join('config', 'locales', '**', 'dog_biscuits.*.yml')].each do |path|
         I18n.load_path.push(path)
       end
+
+      # Adds the `Adventist::TextFileTextExtractionService` to the front of the Hyrax::DerivativeService.services
+      Hyrax::DerivativeService.services.unshift(Adventist::TextFileTextExtractionService)
     end
   end
 end


### PR DESCRIPTION
This commit will make sure that the Adventist's
`TextFileTextExtractionService` is being added to the front of the Hyrax derivative services.

```rb
irb(main):001:0> Hyrax::DerivativeService.services
=> [Adventist::TextFileTextExtractionService, IiifPrint::PluggableDerivativeService]
```