### PR TITLE
🐛 Fix slug based deletion via Hyrax::Transactions

### DIFF
--- a/app/models/concerns/slug_bug.rb
+++ b/app/models/concerns/slug_bug.rb
@@ -28,16 +28,7 @@ module SlugBug
     def remove_index_and_reindex
       return unless slug.present? || slug_for_upgrade.present?
 
-      # if we have a slug with an existing record, previous indexes would have a different id,
-      # resulting extraneous solr indexes remaining (one fedora object with two solr indexes to it)
-      #   1) This happens when a slug gets changed from either empty or a different value
-      #   2) It also apparently happens in some situations where data existed prior to the slug logic
-      # Testing for situation slug_changed? did not adequately prevent the second situation.
-      # This query finds everything indexed by fedora id. The new index will have id: slug
-      Blacklight.default_index.connection.delete_by_query('id:"' + id + '"')
-      # This query finds everything else for this fedora id... if slug changed, may be something here.
-      Blacklight.default_index.connection.delete_by_query('fedora_id_ssi:"' + id + '"')
-      Blacklight.default_index.connection.commit
+      ActiveFedora::Base.remove_from_index!(id)
       update_index
     end
 end

--- a/spec/config/initializers/slug_override_spec.rb
+++ b/spec/config/initializers/slug_override_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "Slug Override" do
+  describe "Fedora records" do
+    let(:work) { FactoryBot.create(:generic_work, aark_id: 'something') }
+    let(:transactions) { Hyrax::Transactions::Container }
+    let(:current_user) { User.find_by(email: work.depositor) }
+
+    # The following logic duplicates the batch delete found here:
+    # https://github.com/samvera/hyrax/blob/b334e186e77691d7da8ed59ff27f091be1c2a700/app/controllers/hyrax/batch_edits_controller.rb#L88-L97
+    it 'deletes via Hyrax::Transactions' do
+      doc_id = work.to_param
+
+      # rubocop:disable Metrics/LineLength
+      expect do
+        resource = Hyrax.query_service.find_by(id: Valkyrie::ID.new(doc_id))
+        transactions['collection_resource.destroy']
+          .with_step_args('collection_resource.delete' => { user: current_user })
+          .call(resource)
+          .value!
+      end.to change { ActiveFedora::SolrService.query("id:\"#{doc_id}\"", fl: "id", method: :post, rows: 1).count }.from(1).to(0)
+      # rubocop:enable Metrics/LineLength
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
The [following code in Hyrax v3.5.0][1] is managing the delete via the
`Hyrax::Transactions` functionality.  The code is as follows:

```ruby
def delete(resource:)
  af_object = ActiveFedora::Base.new
  af_object.id = resource.id
  af_object.delete
  resource
end
```

The primary problem we're encountering is that this instantiates a bare
bones `ActiveFedora::Base` object that has an ID, but no other
properties (in particular the slug, which is the SolrDocument's ID).

This commit repurposes the logic of reindexing when we add/remove an
AARK_ID.  Important is that we attempt deletes both the `id` in
SOLR (which is the Fedora slug value) and delete on the
`fedora_id_ssi` (which is the `resource.id` from above).

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/567

[1]: https://github.com/samvera/hyrax/blob/b334e186e77691d7da8ed59ff27f091be1c2a700/lib/wings/valkyrie/persister.rb#L55-L63