### PR TITLE
🐛 Ensure knapsack translations are first choice

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -34,13 +34,6 @@ CatalogController.configure_blacklight do |config|
   config.add_facet_field 'part_of_sim', limit: 5
   config.add_facet_field 'refereed_sim', limit: 5
 
-  # Prior to this change, the applications specific translations were not loaded.
-  # Dogbiscuits were assuming the translations were already loaded.
-  Rails.root.glob("config/locales/*.yml").each do |path|
-    I18n.load_path << path.to_s
-  end
-  I18n.backend.reload!
-
   # Clobber all existing index and show fields that come from Hyku base but skip
   # the non-DogBiscuit keys that Adventist had already configured in a pre-Knapsack state
   # see: https://github.com/scientist-softserv/adventist-dl/blob/97bd05946345926b2b6c706bd90e183a9d78e8ef/app/controllers/catalog_controller.rb#L38-L40

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -68,10 +68,13 @@ module HykuKnapsack
       end
       ::ApplicationController.send :helper, HykuKnapsack::Engine.helpers
 
-      # Moves the Dog Biscuits locales to the end of the load path
-      Dir[Pathname.new(my_engine_root).join('config', 'locales', '**', 'dog_biscuits.*.yml')].each do |path|
-        I18n.load_path.push(path)
+      # Ensure that all knapsack locales are the "first choice" of keys.
+      HykuKnapsack::Engine.root.glob('config/locales/**/*.*').each do |path|
+        I18n.load_path.push(path.to_s)
       end
+
+      # When we add translation files, we need to load them as well.
+      I18n.backend.reload!
     end
   end
 end

--- a/spec/hyku_knapsack/engine_spec.rb
+++ b/spec/hyku_knapsack/engine_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HykuKnapsack::Engine do
+  describe 'I18n' do
+    it 'has "en.dog_biscuits.fields.date_issued" key' do
+      expect(I18n.t('dog_biscuits.fields.date_issued')).not_to start_with("Translation missing:")
+      expect(I18n.t('dog_biscuits.fields.date_issued')).to eq("Date")
+    end
+  end
+end


### PR DESCRIPTION
Prior to this change, assuming my default translation was "en" when I
called the following—`I18n.t('dog_biscuits.fields.date_issued')`—I would
get `Translation missing: en.dog_biscuits.fields.date_issued`.

We had added DogBiscuits into that path but we had not reloaded the
back-end.

Further, the catalog controller was no longer doing useful work.  The
`Rails.root` is `hyrax-webapp`; which would already be working.  For
more on this anti-pattern, see [Potential Issues Around Knapsack and Rails.root][1].

With this change, I have a small test to verify that dog biscuits
translations are in fact loaded.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/611
- https://github.com/scientist-softserv/adventist-dl/issues/227
- https://github.com/scientist-softserv/adventist-dl/pull/244

[1]: https://github.com/scientist-softserv/adventist_knapsack/issues/60)