### PR TITLE
🐛 Ensure Catalog i18ns favor knapsack

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -43,6 +43,13 @@ CatalogController.configure_blacklight do |config|
 
     config.index_fields.delete(key)
   end
+
+  ##
+  # When we specify the index fields, blacklight caches those translations.  However, in the case of
+  # dogbiscuits, those are not yet loaded.  Which results in a translation error; even though we
+  # later load the dog biscuits translations.
+  HykuKnapsack::Engine.load_translations!
+
   index_props = DogBiscuits.config.index_properties.collect do |prop|
     { prop => CatalogController.send(:index_options, prop, DogBiscuits.config.property_mappings[prop]) }
   end

--- a/spec/controllers/catalog_controller_decorator_spec.rb
+++ b/spec/controllers/catalog_controller_decorator_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CatalogController do
+  describe 'dog biscuits induced catalog translations' do
+    subject { CatalogController.blacklight_config.index_fields.fetch(given_field).label }
+
+    [
+      ["title_tesim", "Title"],
+      ["creator_tesim", "Author"],
+      ["part_of_tesim", "Part of"],
+      ["date_issued_tesim", "Date"],
+      ["subject_tesim", "Subject"],
+      ["source_tesim", "Source"]
+    ].each do |field, label|
+      context field.to_s do
+        let(:given_field) { field }
+
+        it { is_expected.to eq(label) }
+      end
+    end
+  end
+end

--- a/spec/hyku_knapsack/engine_spec.rb
+++ b/spec/hyku_knapsack/engine_spec.rb
@@ -3,10 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe HykuKnapsack::Engine do
-  describe 'I18n' do
-    it 'has "en.dog_biscuits.fields.date_issued" key' do
-      expect(I18n.t('dog_biscuits.fields.date_issued')).not_to start_with("Translation missing:")
-      expect(I18n.t('dog_biscuits.fields.date_issued')).to eq("Date")
+  describe 'I18n.load_path' do
+    it 'has HykuKnapsack translations at a higher precendence than Hyku translations' do
+      hyku_root = Rails.root.to_s
+      knappy_root = described_class.root.to_s
+
+      highest_precedence_knappy = nil
+      highest_precedence_hyku = nil
+
+      # We need to reverse the load_path as later entries in the load path take precedence over
+      # earlier entries in the array.
+      I18n.load_path.reverse.each_with_index do |path, index|
+        if !highest_precedence_hyku && path.start_with?(hyku_root)
+          highest_precedence_hyku = index
+        elsif !highest_precedence_knappy && path.start_with?(knappy_root)
+          highest_precedence_knappy = index
+        end
+        break if highest_precedence_knappy && highest_precedence_hyku
+      end
+
+      # The first encountered translation for knappy happens before the first encountered hyku
+      # translation; meaning that knappy's translations are of higher precedence.
+      expect(highest_precedence_knappy).to be < highest_precedence_hyku
     end
   end
 end


### PR DESCRIPTION
Prior to this change, we had ensured knapsack's translations took
precedence over Hyku's.  However, that ensuring occurred at the
after_initialize.  We had missed the CatalogController's translation
moment as well.

When we specify the index fields in the CatalogController, blacklight
caches those translations.  However, in the case of dogbiscuits, those
are not yet loaded.  Which results in a translation error; even though
we later load the dog biscuits translations.

With this change, I have added two tests to:

1. verify that translations are correct for the catalog controller
2. that when the app boots, the Knapsack translations take precedence
   over Hyku.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/611
- https://github.com/scientist-softserv/adventist-dl/issues/227
- https://github.com/scientist-softserv/adventist-dl/pull/244
- https://github.com/scientist-softserv/adventist_knapsack/pull/63

[1]: https://github.com/scientist-softserv/adventist_knapsack/issues/60)