### PR TITLE
Add app helper for ocr highlighting

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -39,7 +39,7 @@ CatalogController.configure_blacklight do |config|
   # see: https://github.com/scientist-softserv/adventist-dl/blob/97bd05946345926b2b6c706bd90e183a9d78e8ef/app/controllers/catalog_controller.rb#L38-L40
   config.index_fields.keys.each do |key|
     next if key == 'all_text_timv'
-    next if key == 'file_format_tsimv'
+    next if key == 'file_set_text_tsimv'
 
     config.index_fields.delete(key)
   end

--- a/app/helpers/hyku_knapsack/application_helper.rb
+++ b/app/helpers/hyku_knapsack/application_helper.rb
@@ -13,6 +13,25 @@ module HykuKnapsack
     def video_embed_viewer_display_partial(work_presenter)
       'hyrax/base/' + work_presenter.video_embed_viewer.to_s
     end
+
+    ##
+    # This is in place to coerce the :q string to :query for passing the :q value to the query value
+    # of a IIIF Print manifest.
+    #
+    # @param doc [SolrDocument]
+    # @param request [ActionDispatch::Request]
+    def generate_work_url(doc, request)
+      url = super
+      return url unless request.params[:q].present?
+
+      key = doc.any_highlighting? ? 'parent_query' : 'query'
+      query = { key => request.params[:q] }.to_query
+      if url.include?("?")
+        url + "&#{query}"
+      else
+        url + "?#{query}"
+      end
+    end
   end
 
   # A Blacklight index field helper_method

--- a/app/helpers/hyku_knapsack/application_helper.rb
+++ b/app/helpers/hyku_knapsack/application_helper.rb
@@ -22,7 +22,7 @@ module HykuKnapsack
     # @param request [ActionDispatch::Request]
     def generate_work_url(doc, request)
       url = super
-      return url unless request.params[:q].present?
+      return url if request.params[:q].blank?
 
       key = doc.any_highlighting? ? 'parent_query' : 'query'
       query = { key => request.params[:q] }.to_query

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -64,7 +64,6 @@ module HykuKnapsack
         IiifPrint::PluggableDerivativeService
       ]
 
-      my_engine_root = HykuKnapsack::Engine.root.to_s
       # This is the opposite of what you usually want to do.  Normally app views override engine
       # views but in our case things in the Knapsack override what is in the application.
       # Furthermore we need to account for when the ApplicationController and it's descendants set
@@ -78,7 +77,7 @@ module HykuKnapsack
       # propogate to the descendants' copied view_path.
       ([::ApplicationController] + ::ApplicationController.descendants).each do |klass|
         paths = klass.view_paths.collect(&:to_s)
-        paths = [my_engine_root + '/app/views'] + paths
+        paths = [HykuKnapsack::Engine.root.join('app', 'views').to_s] + paths
         klass.view_paths = paths.uniq
       end
       ::ApplicationController.send :helper, HykuKnapsack::Engine.helpers

--- a/spec/helpers/hyku_knapsack/application_helper_spec.rb
+++ b/spec/helpers/hyku_knapsack/application_helper_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HykuKnapsack::ApplicationHelper do
+  let(:helper) { _view }
+
+  let(:cname) { 'hyku-me.test' }
+  let(:account) { build(:search_only_account, cname: cname) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:request) do
+    instance_double(ActionDispatch::Request,
+                    port: 3000,
+                    protocol: "https://",
+                    host: account.cname,
+                    params: { q: q })
+  end
+  let(:doc) { SolrDocument.new(id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname) }
+
+  before do
+    allow(helper).to receive(:current_account) { account }
+  end
+
+  describe '#generate_work_url' do
+    context 'when params has a "q" parameter' do
+      let(:q) { "wonka-vision" }
+
+      context 'when any_highlighting? is false' do
+        it 'passes that along as :query' do
+          expect(doc).to receive(:any_highlighting?).and_return(false)
+          expect(helper.generate_work_url(doc, request)).to end_with("?query=#{q}")
+        end
+      end
+
+      context 'when any_highlighting? is true' do
+        it 'passes that along as :parent_query' do
+          expect(doc).to receive(:any_highlighting?).and_return(true)
+          expect(helper.generate_work_url(doc, request)).to end_with("?parent_query=#{q}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🐛 Ensure we pass query to IIIF viewer

1e14e36bc4937769fd8ccde4306ac5125dcd3b0b

In the pre-knapsack Adventist, the IIIF Print gem overwrote :
`app/views/catalog/_index_header_list_default.html.erb` and the
Adventist Hyku instance did not have that view.

However with the upgrade to the latest Hyku version via Knapsack, that
Hyku overrided Hyrax's view.  And due to view_path issues, we favor the
Hyku instance.

The newer Hyku view override leverages a method that we in the
knapsack (and later in IIIF Print) can extend to inject the parent_query
and query parameter necessary for OCR highlighting.

Below is a *diff of the files in Knapsack's Hyku and IIIF Print*.  I
have not resolved all of these things but am close:

Note that when 'q' is present AND `document.any_highlighting?` is true
we want to pass the param as "parent_query".  If just 'q' is present, we
want to pass "query".  So this is only a partial fix.

<details>
<summary>diff of the files in Knapsack's Hyku and IIIF Print</summary>

```
❯ diff hyrax-webapp/app/views/catalog/_index_header_list_default.html.erb ../iiif_print/app/views/catalog/_index_header_list_default.html.erb
1,2c1,2
< <%# OVERRIDE Hyrax 3.4.0 to support shared search %>
< <% model = document.hydra_model %>
---
> <%# OVERRIDE Hyrax 2.9.6 to show parent_query params if metadata is found in parent record %>
>
4,9c4,12
<     <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
<         <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
<         <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
<     <% else %>
<         <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
<     <% end %>
---
>   <h3 class="search-result-title">
>   <% if params['q'].present? && document.any_highlighting? %>
>     <%= link_to document.title_or_label, [document, { parent_query: params['q'] }] %></h3>
>   <% elsif params['q'].present? %>
>     <%= link_to document.title_or_label, [document, { query: params['q'] }] %></h3>
>   <% else %>
>     <%= link_to document.title_or_label, document %></h3>
>   <% end %>
>   </h3>
```

</details>

Co-authored-by: Kirk Wang <kirk.wang@scientist.com>

## 🧹 Update submodule

8a65998bce21c029e7a0209e0c8a7f820bc5f201

This update will bring in the necessary adjustment to uv.html that
enables the query params to be passed to the UV.

## 🧹 Update submodule

0dcc8b6218d418959447a43740017f77078e3891

Co-authored-by: Kirk Wang <kirk.wang@scientist.com>

## 🐛 Correct typo in `CatalogControllerDecorator`

b47c4f3aa9fe2b014685d00edd495e742b9a8ddd

This commit will correct a typo in the `CatalogControllerDecorator` that
prevented the `file_set_text_tsimv` from being indexed which ultimately
prevented snippet highlighting from working.

## 🧹 Rubucop fix

a8a8a3069ad0b4776abcc400662d0be794cc158b

