### PR TITLE
🧹 Remove unnecessary override

### DIFF
--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -1,7 +1,7 @@
 <% if presenter.thumbnail_path %>
   <%= image_tag presenter.thumbnail_path,
                 class: "representative-media",
-                alt: "",
+                alt: block_for(name: 'default_collection_image_text'),
                 role: "presentation" %>
 <% else %>
   <%= image_tag(Site.instance.default_collection_image) %>


### PR DESCRIPTION
The following commit added the ability to use the alt text for a
default_collection_image_text.  This improves accessibility while also
removing an override file.

https://github.com/samvera/hyku/commit/f28ede597e96d9ccd12e5c27bba08e39f08b56e2

Bellow is the *Diff of knapsack and Hyku file*.

<details><summary>Diff of knapsack and Hyku file</summary>
```
❯ diff app/views/hyrax/collections/_media_display.html.erb hyrax-webapp/app/views/hyrax/collections/_media_display.html.erb
4c4
<                 alt: "",
---
>                 alt: block_for(name: 'default_collection_image_text'),
8c8
< <% end %>
\ No newline at end of file
---
> <% end %>
```
</details>

Related to:

- https://github.com/samvera/hyku/pull/1977