### PR TITLE
Fix homepage layout

### DIFF
--- a/app/assets/stylesheets/adl-overrides/about-section.scss
+++ b/app/assets/stylesheets/adl-overrides/about-section.scss
@@ -26,15 +26,5 @@ body.public-facing {
       margin-top: 0;
       padding-top: 6rem;
     }
-
-    .news-widget-wrapper {
-      border: 1px solid $lightgreyborder;
-      border-radius: 10px;
-      overflow: hidden;
-      .news-widget-scroll {
-        max-height: 550px;
-        overflow-y: scroll;
-      }
-    }
   }
 }

--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap");
-
 body.public-facing {
   font-size: 17px;
   color: $darkgrey;
@@ -25,6 +23,12 @@ body.public-facing {
 
   .lh-40 {
     line-height: 40px;
+  }
+
+  @media (min-width: $sm-min) {
+    .home-content {
+      display: block;
+    }
   }
 
   /* LINK COLORS */

--- a/app/views/adl/_about_section.html.erb
+++ b/app/views/adl/_about_section.html.erb
@@ -1,10 +1,10 @@
 <% if controller_name == 'homepage' %>
   <div class="about-section extended-section-background">
     <% if (display_content_block? @homepage_about_section_heading).present? %>
-      <%= displayable_content_block @homepage_about_section_heading, class: "h2 #{current_account.name != 'adl' ? 'text-center' : "" }" %>
+      <%= displayable_content_block @homepage_about_section_heading, class: "h2 text-center" %>
     <% end %>
     <div class="row pb-5">
-      <div class="about-col col-xs-12 py-5<%= current_account.name == "adl" ? " col-sm-4" : " text-center" %>">
+      <div class="about-col col-xs-12 py-5 text-center">
         <% if (display_content_block? @homepage_about_section_content).present? %>
           <%= displayable_content_block @homepage_about_section_content, class: '' %>
         <% end %>
@@ -13,16 +13,6 @@
           <span class="fa fa-caret-right"></span> 
         <% end %>
       </div>
-      <% if current_account.name == "adl" %>
-        <div class="news-widget-col col-xs-12 py-5 col-sm-8">
-          <h4 class="">Recent News & Updates</h4>
-          <div class= "news-widget-wrapper">
-            <div class="news-widget-scroll">
-              <a class="twitter-timeline" href="https://twitter.com/AdventistDigLib?ref_src=twsrc%5Etfw">Tweets by AdventistDigLib</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-            </div>
-          </div>
-        </div>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
@@ -3,7 +3,8 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body defaultable-fonts">
     <% df = @form.default_values %>
-    <% font = f.object.body_font %>
+    <% body_font = f.object.body_font %>
+    <% headline_font = f.object.headline_font %>
 
     <%= f.input :body_font, label: 'Select Body Font', required: false, input_html: { class: 'font-fields', data: { default_value: df['body_font'] } } %>
     <%= link_to 'Restore Default', '#font', class: 'btn btn-default restore-default-font', data: { default_target: 'body_font' } %>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -26,7 +26,9 @@ body.public-facing h6,
   }
 
 /* LINK COLORS */
-body.public-facing a { color: <%= appearance.link_color %>; }
+/* TODO: Commenting this line out because it somehow causes the footer to use Hyku's default
+         link_color rather than this app's default link_color.  */
+/*  body.public-facing a { color: <%= appearance.link_color %>; } */
 body.public-facing a:hover,
 body.public-facing a:focus { color: <%= appearance.link_hover_color %>; }
 body.public-facing #sort-dropdown .dropdown-toggle,


### PR DESCRIPTION
# Story

This goes beyond handling the "missing collections" mentioned in the ticket (which weren't actually missing... they only appear for tenant 'adl'), and addresses multiple homepage issues:
- remove flex from layout of content in body
- fix font of about section text to respect text selection
- add TODO comment, and comment out dynamic text link color which was not working correctly

Refs:
- https://github.com/scientist-softserv/adventist-dl/issues/593

# Expected Behavior Before Changes

Main page layout did not match current.

# Expected Behavior After Changes

- Fixes layout for about text and collections
- Font text color is correct

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-10-10 at 9 44 58 AM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/a38df279-bbb3-4127-890b-a81bc3f184ad)
![Screenshot 2023-10-10 at 9 45 08 AM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/c10d8d10-7405-4a7a-94c6-c3e99b92c518)
![Screenshot 2023-10-10 at 10 14 57 AM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/4b132228-d27b-482b-847a-bc7283e5eaff)

</details>

# Notes