### PR TITLE
🐛 Render publication_status as multi-value

### DIFF
--- a/app/views/records/edit_fields/_publication_status.html.erb
+++ b/app/views/records/edit_fields/_publication_status.html.erb
@@ -3,4 +3,4 @@
             collection: ps_service.select_active_options,
             include_blank: true,
             item_helper: ps_service.method(:include_current_value),
-            input_html: {class: 'form-control', multiple: false} %>
+            input_html: {class: 'form-control', multiple: true } %>

--- a/app/views/records/show_fields/_publication_status.html.erb
+++ b/app/views/records/show_fields/_publication_status.html.erb
@@ -1,0 +1,2 @@
+<% ps_service = AuthorityService::PublicationStatusesService.new %>
+<%= record.publication_status.map { |ps| ps_service.label(ps) }.join('<br />').html_safe %>


### PR DESCRIPTION
Prior to this commit, we specified that publication_status was a
singular value.  However that broke the general paradigm that most all
Hyrax model properties are multi-value.

What happened was that we would submit `collection[publication_status]`
which was ignored.  When we submit `collection[publication_status][]`
then the property value persists.

We also needed to consider how we'd translate the drop-down value to a
human readable value.  That is done in the corresponding show_fields
page.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/620