### PR TITLE
🐛 Add official_url show partial

### DIFF
--- a/app/views/records/show_fields/_official_url.html.erb
+++ b/app/views/records/show_fields/_official_url.html.erb
@@ -1,0 +1,4 @@
+<% Array(record.official_url).each do |url| %>
+  <%= auto_link(url) { |link| "#{link} <span class='glyphicon glyphicon-new-window'></span>" } %>
+  <br />
+<% end %>


### PR DESCRIPTION
Prior to this commit, because we did not have an official_url partial we
fellback on using the default renderer.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/620
- https://github.com/scientist-softserv/adventist-dl/issues/615

<details aria-hidden>
<summary>Before Change</summary>
<img width="454" alt="Screenshot 2023-10-10 at 11 16 21 AM" src="https://github.com/scientist-softserv/adventist_knapsack/assets/2130/d94d1c5f-b030-4c29-b4bd-c89a7bcb4366">

</details>


<details aria-hidden>
<summary>After Change</summary>
<img width="386" alt="Screenshot 2023-10-10 at 11 13 43 AM" src="https://github.com/scientist-softserv/adventist_knapsack/assets/2130/e74b062f-e95e-4c5c-ba1f-ddefd9dd44f1">

</details>