### PR TITLE
🐛 Fix add to collection by removing spellcheck

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -74,7 +74,6 @@ CatalogController.configure_blacklight do |config|
   config.search_fields.delete('creator')
   config.add_search_field('creator') do |field|
     field.label = "Author"
-    field.solr_parameters = { "spellcheck.dictionary": "creator" }
     solr_name = 'creator_tesim'
     field.solr_local_parameters = {
       qf: solr_name,
@@ -85,14 +84,18 @@ CatalogController.configure_blacklight do |config|
   # TODO: We may remove this block if Hyku changes the date_created search field solr_name
   config.search_fields.delete('date_created')
   config.add_search_field('date_created') do |field|
-    field.solr_parameters = {
-      "spellcheck.dictionary": "date_created"
-    }
     solr_name = ['date_created_tesim', 'sorted_date_isi', 'sorted_month_isi'].join(' ')
     field.solr_local_parameters = {
       qf: solr_name,
       pf: solr_name
     }
+  end
+
+  # Remove spellcheck dictonaries.  This was creating search query errors when attempting to search
+  # within collections.
+  # TODO: Consider moving this to Hyku.
+  config.search_fields.each do |_key, field_config|
+    field_config&.solr_parameters&.delete("spellcheck.dictionary".to_sym)
   end
 
   # Remove all existing sort fields and add the ones we want

--- a/spec/controllers/catalog_controller_decorator_spec.rb
+++ b/spec/controllers/catalog_controller_decorator_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe CatalogController do
         end
       end
     end
+
+    describe 'solr dictionaries' do
+      it 'does not specified spellcheck.dictionaries' do
+        # rubocop:disable Metrics/LineLength
+        expect(blacklight_config.search_fields).to(be_none { |_field, config| config&.solr_parameters&.key?('spellcheck.dictionaries'.to_sym) })
+        # rubocop:enable Metrics/LineLength
+      end
+    end
   end
 end


### PR DESCRIPTION
In looking at the responses, Solr was complaining about a missing
spellcheck.dictionary for contributor.

To get this working, we removed the `spellcheck.dictionary` declaration.
One observation we had is that matches are now only made when we type a
significant number of characters (or 2 words, we don't know what).

An observed ongoing issue is that we're only finding exact matches.

Related:

- https://github.com/scientist-softserv/adventist-dl/issues/623
- https://github.com/scientist-softserv/adventist-dl/issues/622

![Screenshot 2023-10-10 at 1 58 14 PM](https://github.com/scientist-softserv/adventist_knapsack/assets/2130/6f451002-ec60-4f5a-886d-7af81be47a11)

Co-authored-by: LaRita Robinson <larita@scientist.com>