### PR TITLE
🐛 Make date created consistent

### DIFF
--- a/app/models/adventist_metadata.rb
+++ b/app/models/adventist_metadata.rb
@@ -29,8 +29,8 @@ module AdventistMetadata
     # This is for the rights statement
     property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
     property :publisher, predicate: ::RDF::Vocab::DC11.publisher
-    property :date_created, predicate: ::RDF::Vocab::DC.created, multiple: false do |index|
-      index.as :stored_searchable
+    property :date_created, predicate: ::RDF::Vocab::DC.created do |index|
+      index.as :stored_searchable, :facetable, :stored_sortable
     end
     property :subject, predicate: ::RDF::Vocab::DC11.subject
     property :language, predicate: ::RDF::Vocab::DC11.language

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -21,7 +21,7 @@
 <%= presenter.attribute_to_html(:remote_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:extent) %>
-<%= presenter.attribute_to_html(:date_issued, label: 'Date') %>
+<%= presenter.attribute_to_html(:date_issued, label: 'Date Issued') %>
 <%= presenter.attribute_to_html(:alt, label: 'Publication GeoCode') %>
 <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
 <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>

--- a/app/views/journal_articles/edit_fields/_default.html.temp.erb
+++ b/app/views/journal_articles/edit_fields/_default.html.temp.erb
@@ -1,6 +1,0 @@
-<% # the hyrax version of this file messes singular field display %>
-<% if f.object.class.multiple? key %>
-  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
-<% else %>
-  <%= f.input key, required: f.object.required?(key), input_html: { value: f.object.model[key].first } %>
-<% end %>

--- a/app/views/records/edit_fields/_abstract.html.erb
+++ b/app/views/records/edit_fields/_abstract.html.erb
@@ -1,5 +1,0 @@
-<% if f.object.multiple? key %>
-  <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
-<% else %>
-  <%= f.input :abstract, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
-<% end %>

--- a/app/views/records/edit_fields/_date_created.html.erb
+++ b/app/views/records/edit_fields/_date_created.html.erb
@@ -1,7 +1,7 @@
-<% # use date picker %>
+<%# use date picker %>
 
 <% if f.object.class.multiple? key %>
     <%= f.input key, as: :multi_value, input_html: { data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
 <% else %>
-  <%= f.input key, input_html: { value: f.object.model[key].first, data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
+  <%= f.input key, input_html: { value: f.object.model[key]&.first, data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
 <% end %>

--- a/config/locales/dog_biscuits.en.yml
+++ b/config/locales/dog_biscuits.en.yml
@@ -26,7 +26,7 @@ en:
       date_created: Date created
       date_collected: Date collected
       date_copyrighted: Date copyrighted
-      date_issued: Date issued
+      date_issued: Date
       date_of_award: Date of award
       date_published: Publication date
       date_submitted: Date submitted
@@ -151,7 +151,7 @@ en:
         date_created: Date created
         date_collected: Date collected
         date_copyrighted: Date copyrighted
-        date_issued: Date issued
+        date_issued: Date
         date_of_award: Date of award
         date_published: Publication date
         date_submitted: Date submitted

--- a/config/locales/dog_biscuits.en.yml
+++ b/config/locales/dog_biscuits.en.yml
@@ -26,7 +26,7 @@ en:
       date_created: Date created
       date_collected: Date collected
       date_copyrighted: Date copyrighted
-      date_issued: Date
+      date_issued: Date issued
       date_of_award: Date of award
       date_published: Publication date
       date_submitted: Date submitted
@@ -151,7 +151,7 @@ en:
         date_created: Date created
         date_collected: Date collected
         date_copyrighted: Date copyrighted
-        date_issued: Date
+        date_issued: Date issued
         date_of_award: Date of award
         date_published: Publication date
         date_submitted: Date submitted


### PR DESCRIPTION
Ref:
- https://github.com/scientist-softserv/adventist-dl/issues/632 Related to:
- https://github.com/scientist-softserv/adventist_knapsack/pull/77

Property date_created was defined inconsistently, which broke creation and editing of Image and GenericWork types.

This pull request adds a partial with a date picker for date_created and removes `multiple: false` from the definition for GenericWork and Image work types.

Additionally, several unused view partials are being removed, as they were in the wrong path location and would never be hit.

# Story

Refs

- #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
