### PR TITLE
🐛 Require only title and rights_statement

### DIFF
--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -14,7 +14,10 @@ module Hyrax
 
     # Add any local properties here
 
-    self.required_fields = DogBiscuits.config.conference_item_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -14,7 +14,10 @@ module Hyrax
 
     # Add any local properties here
 
-    self.required_fields = DogBiscuits.config.dataset_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/app/forms/hyrax/exam_paper_form.rb
+++ b/app/forms/hyrax/exam_paper_form.rb
@@ -12,7 +12,10 @@ module Hyrax
     # Add any local properties here
     self.terms += []
 
-    self.required_fields = DogBiscuits.config.exam_paper_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -13,7 +13,10 @@ module Hyrax
     # Add any local properties here
     self.terms += []
 
-    self.required_fields = DogBiscuits.config.journal_article_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/app/forms/hyrax/published_work_form.rb
+++ b/app/forms/hyrax/published_work_form.rb
@@ -14,7 +14,10 @@ module Hyrax
 
     # Add any local properties here
 
-    self.required_fields = DogBiscuits.config.published_work_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/app/forms/hyrax/thesis_form.rb
+++ b/app/forms/hyrax/thesis_form.rb
@@ -14,7 +14,10 @@ module Hyrax
 
     # Add any local properties here
 
-    self.required_fields = DogBiscuits.config.thesis_properties_required
+    self.required_fields = %i[
+      title
+      rights_statement
+    ]
 
     # The service that determines the cardinality of each field
     self.field_metadata_service = ::LocalFormMetadataService

--- a/config/initializers/dog_biscuits.rb
+++ b/config/initializers/dog_biscuits.rb
@@ -138,7 +138,6 @@ DogBiscuits.config do |config|
     license
     aark_id
   ]
-  config.conference_item_properties_required = Hyrax::GenericWorkForm.required_fields
 
   config.dataset_properties = %i[
     creator
@@ -168,7 +167,6 @@ DogBiscuits.config do |config|
     source
     aark_id
   ]
-  config.dataset_properties_required = Hyrax::GenericWorkForm.required_fields
 
   config.exam_paper_properties = %i[
     creator
@@ -190,7 +188,6 @@ DogBiscuits.config do |config|
     source
     aark_id
   ]
-  config.exam_paper_properties_required = Hyrax::GenericWorkForm.required_fields
 
   config.journal_article_properties = %i[
     title
@@ -228,7 +225,6 @@ DogBiscuits.config do |config|
     bibliographic_citation
     alt
   ]
-  config.journal_article_properties_required = Hyrax::GenericWorkForm.required_fields
 
   config.published_work_properties = %i[
     title
@@ -263,7 +259,6 @@ DogBiscuits.config do |config|
     alt
     bibliographic_citation
   ]
-  config.published_work_properties_required = Hyrax::GenericWorkForm.required_fields
 
   config.thesis_properties = %i[
     title
@@ -298,7 +293,6 @@ DogBiscuits.config do |config|
     bibliographic_citation
     alt
   ]
-  config.thesis_properties_required = Hyrax::GenericWorkForm.required_fields
 
   # PROPERTY MAPPINGS
   config.property_mappings[:bibliographic_citation] = { label: 'Bibliographic Citation' }

--- a/spec/forms/hyrax/conference_item_form_spec.rb
+++ b/spec/forms/hyrax/conference_item_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ConferenceItemForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end

--- a/spec/forms/hyrax/conference_item_form_spec.rb
+++ b/spec/forms/hyrax/conference_item_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::ConferenceItemForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::DatasetForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::DatasetForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end

--- a/spec/forms/hyrax/exam_paper_form_spec.rb
+++ b/spec/forms/hyrax/exam_paper_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ExamPaperForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end

--- a/spec/forms/hyrax/exam_paper_form_spec.rb
+++ b/spec/forms/hyrax/exam_paper_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::ExamPaperForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/generic_work_form_decorator_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_decorator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Hyrax::GenericWorkForm do
 
     describe '.required_fields' do
       subject { described_class.required_fields }
-  
-      it { is_expected.to match_array [:rights_statement, :title] }
+
+      it { is_expected.to match_array %i[rights_statement title] }
     end
   end
 end

--- a/spec/forms/hyrax/generic_work_form_decorator_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_decorator_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe Hyrax::GenericWorkForm do
         ].sort
       )
     end
+
+    describe '.required_fields' do
+      subject { described_class.required_fields }
+  
+      it { is_expected.to match_array [:rights_statement, :title] }
+    end
   end
 end

--- a/spec/forms/hyrax/image_form_decorator_spec.rb
+++ b/spec/forms/hyrax/image_form_decorator_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe Hyrax::ImageForm do
         ].sort
       )
     end
+
+    describe '.required_fields' do
+      subject { described_class.required_fields }
+  
+      it { is_expected.to match_array [:rights_statement, :title] }
+    end
   end
 end

--- a/spec/forms/hyrax/image_form_decorator_spec.rb
+++ b/spec/forms/hyrax/image_form_decorator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Hyrax::ImageForm do
 
     describe '.required_fields' do
       subject { described_class.required_fields }
-  
-      it { is_expected.to match_array [:rights_statement, :title] }
+
+      it { is_expected.to match_array %i[rights_statement title] }
     end
   end
 end

--- a/spec/forms/hyrax/journal_article_form_spec.rb
+++ b/spec/forms/hyrax/journal_article_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::JournalArticleForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/journal_article_form_spec.rb
+++ b/spec/forms/hyrax/journal_article_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::JournalArticleForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end

--- a/spec/forms/hyrax/published_work_form_spec.rb
+++ b/spec/forms/hyrax/published_work_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PublishedWorkForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end

--- a/spec/forms/hyrax/published_work_form_spec.rb
+++ b/spec/forms/hyrax/published_work_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::PublishedWorkForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/thesis_form_spec.rb
+++ b/spec/forms/hyrax/thesis_form_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Hyrax::ThesisForm do
   describe '.required_fields' do
     subject { described_class.required_fields }
 
-    it { is_expected.to match_array [:rights_statement, :title] }
+    it { is_expected.to match_array %i[rights_statement title] }
   end
 end

--- a/spec/forms/hyrax/thesis_form_spec.rb
+++ b/spec/forms/hyrax/thesis_form_spec.rb
@@ -5,7 +5,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ThesisForm do
-  it "has tests" do
-    skip "Add your tests here"
+  describe '.required_fields' do
+    subject { described_class.required_fields }
+
+    it { is_expected.to match_array [:rights_statement, :title] }
   end
 end


### PR DESCRIPTION
# Story

Ref:
- https://github.com/scientist-softserv/adventist-dl/issues/627

# Expected Behavior Before Changes

Only Image and GenericWork types had correct required terms

# Expected Behavior After Changes

All work types require only title and rights statement.

# Screenshots / Video

<details>
<summary></summary>

**Before:**
![Screenshot 2023-10-12 at 12 06 15 PM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/a0f74682-522e-479d-8803-0797a4da5556)

**After:**
![Screenshot 2023-10-12 at 12 05 24 PM](https://github.com/scientist-softserv/adventist_knapsack/assets/17851674/a7ea3a4a-008d-4544-8d73-00e983725621)

</details>

# Notes
