### PR TITLE
🐛 Remove CollectionForm#alternative_title

### DIFF
--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -1,16 +1,42 @@
 # frozen_string_literal: true
 
-module Hyrax
+##
+# Yes, this needs to be HykuKnapsack.  In prior commits, we had Hyrax and the specs failed (because
+# Hyku has a Hyrax::Forms::CollectionFormDecorator which was getting loaded/parsed and collaborating
+# on the problem regarding {alternative_title}).
+module HykuKnapsack
   module Forms
     module CollectionFormDecorator
       # Terms that appear within the accordion
       def secondary_terms
-        (super + Collection.additional_terms).sort
+        (super + Collection.additional_terms - [:alternative_title]).sort.uniq
       end
+
+      ##
+      # What the heck is going on here?
+      #
+      # As part of https://github.com/scientist-softserv/adventist_knapsack/pull/87 we have
+      # attempted to rid the collection form of the alternative_title (to deal with the conflicting
+      # predicate for slugs).  However, it is declared by way of
+      # `Hyrax::Forms::CollectionForm.delegate(:alternative_title, to: :model)`
+      #
+      # Which means that we cannot rely on `remove_method` to tidy this up.  Instead we declare the
+      # method (thus obliterating the delegation).  We then use Ruby's `undef_method` which
+      # instructs the object to no longer `respond_to` the undefined method.  See the tests for
+      # clarification.
+      #
+      # Yes, I'm saying NotImplementedError and testing for NoMethodError; because `undef_method`
+      # cleans this mess up.
+      def alternative_title
+        raise NotImplementedError, "Removed #{self.class}#alternative_title for Slug interaction."
+      end
+      undef_method(:alternative_title)
     end
   end
 end
 
 Hyrax::Forms::CollectionForm.terms += Collection.additional_terms
+# Somehow, someway the alternative_title keeps showing up as one of the terms.  This is yet another
+# step we take to eliminate that.
 Hyrax::Forms::CollectionForm.terms -= [:alternative_title]
-Hyrax::Forms::CollectionForm.prepend(Hyrax::Forms::CollectionFormDecorator)
+Hyrax::Forms::CollectionForm.prepend(HykuKnapsack::Forms::CollectionFormDecorator)

--- a/spec/forms/hyrax/forms/collection_form_decorator_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_decorator_spec.rb
@@ -3,6 +3,22 @@
 require 'spec_helper'
 
 RSpec.describe Hyrax::Forms::CollectionForm do
+  describe 'instance' do
+    subject { described_class.new(collection, ability, repository) }
+
+    let(:collection) { Collection.new }
+    let(:ability) { Ability.new(build(:user)) }
+    let(:repository) { double }
+
+    it { is_expected.not_to respond_to :alternative_title }
+
+    describe 'calling #alternative_title' do
+      it "raises a NoMethodError" do
+        expect { subject.alternative_title }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
   describe '.terms' do
     subject { described_class.terms.sort }
 


### PR DESCRIPTION
The inline comments explain best:

> As part of [PR 87][87] we have attempted to rid the collection form of
> the alternative_title (to deal with the conflicting predicate for
> slugs).  However, it is declared by way of
> `Hyrax::Forms::CollectionForm.delegate(:alternative_title, to: > :model)`
>
> Which means that we cannot rely on `remove_method` to tidy this up.
> Instead we declare the method (thus obliterating the delegation).
> We then use Ruby's `undef_method` which instructs the object to no
> longer `respond_to` the undefined method.  See the tests for
> clarification.

Further, I've discovered that re-using a decorator that was declared in
Hyku resulted in the Knapsack decorator not working; hence the rename.

Related to:

- https://github.com/scientist-softserv/adventist_knapsack/pull/87
- https://playbook-staging.notch8.com/en/samvera/custom-slugs
- https://github.com/scientist-softserv/adventist-dl/issues/620
- https://github.com/scientist-softserv/adventist-dl/issues/578

[87]: https://github.com/scientist-softserv/adventist_knapsack/pull/87