### PR TITLE
🐛 Fix UV download option for PDFs

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
@@ -8,19 +8,6 @@ module HykuKnapsack
       returning_hash
     end
 
-    def rendering(presenter:)
-      file_set_presenters = presenter.file_set_presenters.reject { |fsp| fsp.mime_type.include?('image') }
-
-      file_set_presenters.map do |fsp|
-        {
-          # Yes, we are using `#send` because `#hostname` is a private method, though I think it's okay here
-          "@id": Hyrax::Engine.routes.url_helpers.download_url(fsp.id, host: presenter.send(:hostname)),
-          "label": fsp.label,
-          "format": fsp.mime_type
-        }
-      end
-    end
-
     def sanitize_v2(hash:, presenter:, solr_doc_hits:)
       hash['label'] = sanitize_label(hash['label']) if hash.key?('label')
       hash.delete('description') # removes default description since it's in the metadata fields
@@ -38,11 +25,31 @@ module HykuKnapsack
       hash
     end
 
-    def sanitize_label(label)
-      CGI.unescapeHTML(sanitize_value(label))
-    end
+    private
+
+      def rendering(presenter:)
+        model = presenter.solr_document['has_model_ssim'].first
+        # Our current presenter is a IiifManifestPresenter, which doesn't have the file_set_presenters we need.
+        # So we create a Hyrax presenter for the model, and use that to get the file_set_presenters.
+        hyrax_presenter = "Hyrax::#{model}Presenter".constantize.new(presenter, presenter.ability)
+        file_set_presenters = hyrax_presenter.file_set_presenters.reject { |fsp| fsp.mime_type.include?('image') }
+
+        file_set_presenters.map do |fsp|
+          {
+            # Yes, we are using `#send` because `#hostname` is a private method, though I think it's okay here
+            "@id": Hyrax::Engine.routes.url_helpers.download_url(fsp.id,
+                                                                 host: presenter.send(:hostname),
+                                                                 protocol: 'https'),
+            "label": fsp.label,
+            "format": fsp.mime_type
+          }
+        end
+      end
+
+      def sanitize_label(label)
+        CGI.unescapeHTML(sanitize_value(label))
+      end
   end
 end
-# rubocop:enable Metrics/BlockLength
 
 Hyrax::ManifestBuilderService.prepend(HykuKnapsack::ManifestBuilderServiceDecorator)


### PR DESCRIPTION
# Story

This commit will adjust the #rendering for maninfests to render a PDF download option for UV.  After the upgrade, IiifManifestPresenters don't seem to have the file_set_presenters we're looking for anymore.  We instead instantiate a Hyrax presenter which does have the needed file_set_presenters.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/637

# Expected Behavior Before Changes
PDF works did not render a download option in the UV.

# Expected Behavior After Changes
PDF works now will render a download option in the UV.

# Screenshots / Video
<img width="878" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/02c0a5bb-959a-4738-8bab-80fafd5364f7">
