### PR TITLE
:broom: Increase resources for staging

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -2,11 +2,11 @@ replicaCount: 2
 
 resources:
   requests:
-    memory: "4Gi"
-    cpu: "1000m"
+    memory: "1Gi"
+    cpu: "250m"
   limits:
-    memory: "8Gi"
-    cpu: "2000m"
+    memory: "2Gi"
+    cpu: "1000m"
 
 livenessProbe:
   enabled: false


### PR DESCRIPTION
Deploying to staging is failing with the error message: '3 insufficient cpu, 3 insufficient memory'. Maybe increasing the resources will help.

![image (41)](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/0e0862d0-b824-4c07-8e41-d8a607ab7d01)
