### PR TITLE
🐛 Fix invalid date error

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -30,9 +30,9 @@
 
 <%= presenter.attribute_to_html(:presented_at, label: I18n.t('dog_biscuits.fields.presented_at')) %>
 <%= presenter.attribute_to_html(:location, label: I18n.t('dog_biscuits.fields.location')) %>
-<%= presenter.attribute_to_html(:event_date, label: I18n.t('dog_biscuits.fields.event_date'), render_as: :date) %>
+<%= presenter.attribute_to_html(:event_date, label: I18n.t('dog_biscuits.fields.event_date')) %>
 <%= presenter.attribute_to_html(:editor, label: I18n.t('dog_biscuits.fields.editor')) %>
-<%= presenter.attribute_to_html(:date_published, label: I18n.t('dog_biscuits.fields.date_published'), render_as: :date) %>
+<%= presenter.attribute_to_html(:date_published, label: I18n.t('dog_biscuits.fields.date_published')) %>
 <%= presenter.attribute_to_html(:publication_status, label: I18n.t('dog_biscuits.fields.publication_status'), render_as: :faceted) %>
 <%= presenter.attribute_to_html(:refereed, render_as: :faceted, label: I18n.t('dog_biscuits.fields.refereed')) %>
 <%= presenter.attribute_to_html(:pagination, label: I18n.t('dog_biscuits.fields.pagination')) %>
@@ -41,8 +41,8 @@
 <%= presenter.attribute_to_html(:resource_type_general, label: I18n.t('dog_biscuits.fields.resource_type_general')) %>
 <%= presenter.attribute_to_html(:funder, label: I18n.t('dog_biscuits.fields.funder'), render_as: :faceted) %>
 <%= presenter.attribute_to_html(:output_of, label: I18n.t('dog_biscuits.fields.output_of')) %>
-<%= presenter.attribute_to_html(:date_collected, label: I18n.t('dog_biscuits.fields.date_collected'), render_as: :date) %>
-<%= presenter.attribute_to_html(:date_created, label: I18n.t('dog_biscuits.fields.date_created'), render_as: :date) %>
+<%= presenter.attribute_to_html(:date_collected, label: I18n.t('dog_biscuits.fields.date_collected')) %>
+<%= presenter.attribute_to_html(:date_created, label: I18n.t('dog_biscuits.fields.date_created')) %>
 <%= presenter.attribute_to_html(:dc_format, label: I18n.t('dog_biscuits.fields.dc_format')) %>
 <%= presenter.attribute_to_html(:department, label: I18n.t('dog_biscuits.fields.department'), render_as: :faceted) %>
 <%= presenter.attribute_to_html(:qualification_level, label: I18n.t('dog_biscuits.fields.qualification_level')) %>
@@ -50,16 +50,16 @@
 <%= presenter.attribute_to_html(:module_code, label: I18n.t('dog_biscuits.fields.module_code')) %>
 <%= presenter.attribute_to_html(:volume_number, label: I18n.t('dog_biscuits.fields.volume_number')) %>
 <%= presenter.attribute_to_html(:issue_number, label: I18n.t('dog_biscuits.fields.issue_number')) %>
-<%= presenter.attribute_to_html(:date_submitted, label: I18n.t('dog_biscuits.fields.date_submitted'), render_as: :date) %>
-<%= presenter.attribute_to_html(:date_accepted, label: I18n.t('dog_biscuits.fields.date_accepted'), render_as: :date) %>
-<%= presenter.attribute_to_html(:date_available, label: I18n.t('dog_biscuits.fields.date_available'), render_as: :date) %>
+<%= presenter.attribute_to_html(:date_submitted, label: I18n.t('dog_biscuits.fields.date_submitted')) %>
+<%= presenter.attribute_to_html(:date_accepted, label: I18n.t('dog_biscuits.fields.date_accepted')) %>
+<%= presenter.attribute_to_html(:date_available, label: I18n.t('dog_biscuits.fields.date_available')) %>
 <%= presenter.attribute_to_html(:edition, label: I18n.t('dog_biscuits.fields.edition')) %>
 <%= presenter.attribute_to_html(:part, label: I18n.t('dog_biscuits.fields.part')) %>
 <%= presenter.attribute_to_html(:series, label: I18n.t('dog_biscuits.fields.series')) %>
 <%= presenter.attribute_to_html(:isbn, label: I18n.t('dog_biscuits.fields.isbn')) %>
 <%= presenter.attribute_to_html(:advisor, label: I18n.t('dog_biscuits.fields.advisor')) %>
 <%= presenter.attribute_to_html(:awarding_institution, label: I18n.t('dog_biscuits.fields.awarding_institution')) %>
-<%= presenter.attribute_to_html(:date_of_award, label: I18n.t('dog_biscuits.fields.date_of_award'), render_as: :date) %>
+<%= presenter.attribute_to_html(:date_of_award, label: I18n.t('dog_biscuits.fields.date_of_award')) %>
 
 <%= presenter.attribute_to_html(:description) %>
 <%= presenter.attribute_to_html(:abstract) %>


### PR DESCRIPTION
# Story

When using the `#attribute_to_html` method, passing in the `render_as: :date` argument seem to sometimes cause invalid dates.  When the string is 11/08/2023, it gets parsed as August 8th, 2023.  This is a problem when you have a date like 11/13/2023, because there is no 13th month.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/641

# Screenshots / Video

## Before:
<img width="799" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/c5c8abca-8927-4690-a35c-6a58eb182454">


## After:
<img width="1349" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/a8933a6d-da9a-4d5c-b28d-f8d7e5211590">
