### PR TITLE
🎁 Work show pg: Display Part Of as Periodical for Journal Articles

### DIFF
--- a/app/presenters/hyku/work_show_presenter_decorator.rb
+++ b/app/presenters/hyku/work_show_presenter_decorator.rb
@@ -9,6 +9,17 @@ module Hyku
     def video_embed_viewer
       :video_embed_viewer
     end
+
+    def part_of_label
+      klass = model_klass
+      klass == JournalArticle ? 'Periodical' : 'Part Of'
+    end
+    
+    private
+    
+    def model_klass
+      model_name.instance_variable_get(:@klass)
+    end
   end
 end
 

--- a/app/presenters/hyku/work_show_presenter_decorator.rb
+++ b/app/presenters/hyku/work_show_presenter_decorator.rb
@@ -14,12 +14,12 @@ module Hyku
       klass = model_klass
       klass == JournalArticle ? 'Periodical' : 'Part Of'
     end
- 
-      private
 
-      def model_klass
-        model_name.instance_variable_get(:@klass)
-      end
+    private
+
+    def model_klass
+      model_name.instance_variable_get(:@klass)
+    end
   end
 end
 

--- a/app/presenters/hyku/work_show_presenter_decorator.rb
+++ b/app/presenters/hyku/work_show_presenter_decorator.rb
@@ -17,9 +17,9 @@ module Hyku
 
     private
 
-    def model_klass
-      model_name.instance_variable_get(:@klass)
-    end
+      def model_klass
+        model_name.instance_variable_get(:@klass)
+      end
   end
 end
 

--- a/app/presenters/hyku/work_show_presenter_decorator.rb
+++ b/app/presenters/hyku/work_show_presenter_decorator.rb
@@ -14,12 +14,12 @@ module Hyku
       klass = model_klass
       klass == JournalArticle ? 'Periodical' : 'Part Of'
     end
-    
-    private
-    
-    def model_klass
-      model_name.instance_variable_get(:@klass)
-    end
+ 
+      private
+
+      def model_klass
+        model_name.instance_variable_get(:@klass)
+      end
   end
 end
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -12,7 +12,7 @@
 <% if can? :read, :admin_dashboard %>
   <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <% end %>
-<%= presenter.attribute_to_html(:part_of, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:part_of, render_as: :faceted, label: presenter.part_of_label) %>
 <%= presenter.attribute_to_html(:source, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:aark_id, label: I18n.t('dog_biscuits.fields.aark_id')) %>
 <%= presenter.attribute_to_html(:place_of_publication) %>


### PR DESCRIPTION
In the non knapsack app, the part of label was called "Periodical" for Journal Article work types. For the sake of consistency, the client would like to keep it this way.

Issue:
- https://github.com/scientist-softserv/adventist-dl/issues/658

# Screenshot

![Screenshot 2023-11-20 at 12-27-01 $1 million in tithe reached by one church](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/30c7680d-de45-4878-a45b-e7d37070272c)

## Notes

Adventist proper had a conditional in the [attribute_rows partial](https://github.com/scientist-softserv/adventist-dl/blob/92879b9c2c8e48c410ff4c8918019f8a8fd39607/app/views/hyrax/journal_articles/_attribute_rows.html.erb#L16-L20) to change the display label. This conditional no longer exists in adventist knapsack, so the fix was to add a label. 

![Screenshot 2023-11-20 at 12-28-04 Code search results](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/629ae674-ac76-475e-81cb-768cd88470a8)

# TODO

We need to bring back a conditional label. For example, Generic Work's part of would now say Periodical. It seems as though that label should only apply to Article work types. 

[Staging](https://sdapi.s2.adventistdigitallibrary.org/concern/generic_works/dd57667d-7ae3-413c-a2c8-1cdd4bbebcc7?locale=en) example of Generic Work confirms this: 

<img width="1261" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/095826c9-883b-4344-b38c-20dbf08255b8">
