### PR TITLE
🐛 Update webapp for public #solr_document

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -26,7 +26,7 @@ jobs:
 
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@fix_spec_reports
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.15
     with:
       confdir: '/app/samvera/hyrax-webapp/solr/conf'
       webTarget: hyku-web
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@fix_spec_reports
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.15
     with:
       webTarget: hyku-web
       workerTarget: hyku-worker


### PR DESCRIPTION
# Story

This commit will update the hyrax-webapp submodule where we move the `#solr_document` method from private to public.  The method being private was causing a crash in the Universal Viewer.  As per Hyrax, the method should have been public in the first place.

Ref:
  - https://github.com/samvera/hyku/commit/dbe996e71afa63a5ba8f68f55e4c50ed25d3729d
  - https://github.com/samvera/hyrax/blob/b334e186e77691d7da8ed59ff27f091be1c2a700/app/presenters/hyrax/file_set_presenter.rb#L10
  - https://github.com/scientist-softserv/adventist-dl/issues/624

# Screenshots / Video

## Before (on staging)
<img width="1361" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/40dc261a-943d-4e2a-bdea-ad5b8b648b90">

## After
<img width="1575" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/f5777733-55af-4bb6-8cae-18739a487633">
