### PR TITLE
:broom: disable production deploy option until we're ready

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ on:
         type: choice
         options:
           - staging
-          - production
+          # - production
       debug_enabled:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'


### PR DESCRIPTION
# Story

Disable the deploy to production option, until we're ready to go live with this app/repo. The host points to our current production domain. This is being done to prevent us from accidentally deploying to production until it's time to truly do so. 