### PR TITLE
i664 restore Helvetica Neue as the default font

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gemspec
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 
-# The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
-gem 'json-canonicalization', "0.3.1"
-
 gemfile_path = File.expand_path("hyrax-webapp/Gemfile", __dir__)
 if File.exist?(gemfile_path)
   gemfile = File.read(gemfile_path).split("\n").reject { |l| l.match('knapsack') }

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gemspec
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 
+# The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
+gem 'json-canonicalization', "0.3.1"
+
 gemfile_path = File.expand_path("hyrax-webapp/Gemfile", __dir__)
 if File.exist?(gemfile_path)
   gemfile = File.read(gemfile_path).split("\n").reject { |l| l.match('knapsack') }

--- a/app/forms/hyrax/forms/admin/appearance_decorator.rb
+++ b/app/forms/hyrax/forms/admin/appearance_decorator.rb
@@ -27,8 +27,8 @@ module Hyrax
         }.freeze
 
         ADL_DEFAULT_FONTS = {
-          'body_font'     => 'Nobile, sans-serif;',
-          'headline_font' => 'Nobile, sans-serif;'
+          'body_font'     => 'Helvetica Neue, Helvetica, Arial, sans-serif;',
+          'headline_font' => 'Helvetica Neue, Helvetica, Arial, sans-serif;'
         }.freeze
 
         # OVERRIDE to add adventist's custom header & footer


### PR DESCRIPTION
In prod, Helvetica Neue is the default font, but in knapsack it was Nobile. The client has requested feature parity with prod.

Issue:
- https://github.com/scientist-softserv/adventist-dl/issues/664

Related (Prod):
- https://github.com/scientist-softserv/adventist-dl/blob/7c2c64939044d61fd3a210e95fc3bcba761b79ae/app/forms/hyrax/forms/admin/appearance.rb#L14-L17

## AFTER Screenshot: 

- [ ] clicking "restore all defaults" sets the font to Helvetica Neue

<img width="1152" alt="Screenshot 2024-02-12 at 2 36 17 PM" src="https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/5440f943-5694-4232-ad8f-b300e4bf5332">


