### PR TITLE
:bug: i693 - controlled vocab location dropdown does not load

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -16,4 +16,9 @@ Hyrax.config do |config|
   # Also, we will continue to extract txt file's text using Adventist::TextFileTextExtractionService
   config.extract_full_text = false
   config.work_requires_files = false
+
+  # Location autocomplete uses geonames to search for named regions.
+  # Specify the user for connecting to geonames:
+  # Register here: http://www.geonames.org/manageaccount
+  config.geonames_username = 'jcoyne'
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -20,5 +20,5 @@ Hyrax.config do |config|
   # Location autocomplete uses geonames to search for named regions.
   # Specify the user for connecting to geonames:
   # Register here: http://www.geonames.org/manageaccount
-  config.geonames_username = 'jcoyne'
+  config.geonames_username = ENV.fetch('HYKU_GEONAMES_USERNAME', 'jcoyne')
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1083,6 +1083,7 @@ en:
         title: A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository.
       collection:
         based_near: A place name related to the collection, such as its site of publication, or the city, state, or country the collection contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
+        based_near_label: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
         contributor: A person or group you want to recognize for playing a role in the creation of the collection, but not the primary role.
         creator: The person or group responsible for the collection. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
         date_created: The date on which the collection was created.

--- a/ops/dev-deploy.tmpl.yaml
+++ b/ops/dev-deploy.tmpl.yaml
@@ -94,6 +94,8 @@ extraEnvVars: &envVars
     value: 'changeme@example.com'
   - name: HYKU_DEFAULT_HOST
     value: "%{tenant}.s2.adventistdigitallibrary.org"
+  - name: HYKU_GEONAMES_USERNAME
+    value: 'scientist'
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_ROOT_HOST

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -100,6 +100,8 @@ extraEnvVars: &envVars
     value: "%{tenant}.b2.adventistdigitallibrary.org"
   - name: HYKU_FILE_ACL
     value: "false"
+  - name: HYKU_GEONAMES_USERNAME
+    value: 'scientist'
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_ROOT_HOST

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -95,6 +95,8 @@ extraEnvVars: &envVars
     value: "8080"
   - name: FCREPO_REST_PATH
     value: rest
+  - name: HYKU_GEONAMES_USERNAME
+    value: 'jcoyne'
   # - name: GOOGLE_ANALYTICS_ID
   #   value: $GOOGLE_ANALYTICS_ID
   # - name: GOOGLE_OAUTH_APP_NAME

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -96,7 +96,7 @@ extraEnvVars: &envVars
   - name: FCREPO_REST_PATH
     value: rest
   - name: HYKU_GEONAMES_USERNAME
-    value: 'jcoyne'
+    value: 'scientist'
   # - name: GOOGLE_ANALYTICS_ID
   #   value: $GOOGLE_ANALYTICS_ID
   # - name: GOOGLE_OAUTH_APP_NAME


### PR DESCRIPTION
Add missing translation for based_near label. Add geonames_username configuration to hyrax initializer to match production settings.

Issue
- https://github.com/scientist-softserv/adventist-dl/issues/693

Before this commit, the location does not load

<img width="594" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/9cb32c75-1909-4eb3-89a3-a85660bbf2c4">



After, the location field is a controlled vocabulary drop down with populated options.

<img width="572" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/291990f4-1234-4827-9c5b-bad021720f97">

