### PR TITLE
:broom: i724 - Update styling for collection show page

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -349,6 +349,16 @@ body.public-facing {
 
   //COLLECTION-SHOW PAGE
 
+  .hyc-title h1 {
+    color: rgb(44,44,44);
+    text-shadow: none;
+  }
+
+  .hyc-last-updated {
+    color: rgb(44,44,44);
+    text-shadow: none;
+  }
+
   .hyc-metadata,
   .hyc-description {
     padding: 1em;


### PR DESCRIPTION
Collection show page text appears white with a text-shadow. The client wants feature parity with production, which is dark colored text and no text-shadow.

Issue:
- https://github.com/scientist-softserv/adventist-dl/issues/724



# Expected Behavior Before Changes

![Screenshot 2024-02-13 at 12-14-12 Random folder of cool stuff __ Hyku](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/c0b4ee5b-1c6c-46a1-bc08-29774e5bcdba)

# Expected Behavior After Changes
![Screenshot 2024-02-13 at 12-14-25 collection test __ Hyku](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/9f789872-b08f-4252-9217-9e5f6e339425)



