### PR TITLE
Revert HYKU_GEONAMES_USERNAME setting because...

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -16,9 +16,4 @@ Hyrax.config do |config|
   # Also, we will continue to extract txt file's text using Adventist::TextFileTextExtractionService
   config.extract_full_text = false
   config.work_requires_files = false
-
-  # Location autocomplete uses geonames to search for named regions.
-  # Specify the user for connecting to geonames:
-  # Register here: http://www.geonames.org/manageaccount
-  config.geonames_username = ENV.fetch('HYKU_GEONAMES_USERNAME', 'jcoyne')
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1082,8 +1082,8 @@ en:
         description: A brief overarching description that applies to all works collected in this set. For example, "Theses and supplementary files created by the School of Earth Sciences graduate students."
         title: A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository.
       collection:
-        based_near: A place name related to the collection, such as its site of publication, or the city, state, or country the collection contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
-        based_near_label: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
+        based_near: "A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>. Please note, you must configure your geonames username in the account settings, or this field will have a loading error.</br>
+        </br><b>Steps to enable this field:</b><br/>1. Create a free account on the <a href='http://www.geonames.org'>Geonames web service page.</a></br>2. Go to your <a href='http://www.geonames.org/manageaccount'>geonames account settings</a> and select the option at the bottom to enable free services.</br>3. Go into your hyku account settings in the <a href='/admin/account/edit?locale=en'>dashboard.</a></br>4. Enter your geonames username in the hyrax account settings.<br/>5. You should now be able to see the list of locations in this dropdown."
         contributor: A person or group you want to recognize for playing a role in the creation of the collection, but not the primary role.
         creator: The person or group responsible for the collection. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
         date_created: The date on which the collection was created.
@@ -1110,7 +1110,8 @@ en:
         share_applies_to_new_works: When new works are created directly in the collection, grant sharing users and groups permissions for the new work according to their collection roles.
         title: ""
       defaults:
-        based_near: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
+        based_near: "A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>. Please note, you must configure your geonames username in the account settings, or this field will have a loading error.</br>
+        </br><b>Steps to enable this field:</b><br/>1. Create a free account on the <a href='http://www.geonames.org'>Geonames web service page.</a></br>2. Go to your <a href='http://www.geonames.org/manageaccount'>geonames account settings</a> and select the option at the bottom to enable free services.</br>3. Go into your hyku account settings in the <a href='/admin/account/edit?locale=en'>dashboard.</a></br>4. Enter your geonames username in the hyrax account settings.<br/>5. You should now be able to see the list of locations in this dropdown."
         contributor: A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.
         creator: The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
         date_created: The date on which the work was created.

--- a/ops/dev-deploy.tmpl.yaml
+++ b/ops/dev-deploy.tmpl.yaml
@@ -94,8 +94,6 @@ extraEnvVars: &envVars
     value: 'changeme@example.com'
   - name: HYKU_DEFAULT_HOST
     value: "%{tenant}.s2.adventistdigitallibrary.org"
-  - name: HYKU_GEONAMES_USERNAME
-    value: 'scientist'
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_ROOT_HOST

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -100,8 +100,6 @@ extraEnvVars: &envVars
     value: "%{tenant}.b2.adventistdigitallibrary.org"
   - name: HYKU_FILE_ACL
     value: "false"
-  - name: HYKU_GEONAMES_USERNAME
-    value: 'scientist'
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_ROOT_HOST

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -123,8 +123,6 @@ extraEnvVars: &envVars
     value: "%{tenant}.adventist-knapsack-staging.notch8.cloud"
   - name: HYKU_FILE_ACL
     value: "false"
-  - name: HYKU_GEONAMES_USERNAME 
-    value: 'scientist'
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_ROOT_HOST


### PR DESCRIPTION
This PR corrects and reverts a [previous one](https://github.com/scientist-softserv/adventist_knapsack/pull/115). 

According to Hyku's docs, the geoname should be set using [HYKU_GEONAMES_USERNAME](https://github.com/samvera/hyku?tab=readme-ov-file#environment-variables) but that is not true. 

Geonames is a setting on the tenant's account. Setting the env works for local development, but doesn't fix the problem once deployed because of [this](https://github.com/samvera/hyku/blob/main/app/models/concerns/account_settings.rb).

Code has been reverted and the help text has been updated to better clarify the how-to with the user. 

![image](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/6c7f7c17-fcf1-433d-80bd-7df6906e40d5)

![image](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/9981b8b9-6ac8-4f05-bb52-444cbaac85d9)


 