### PR TITLE
🐛 Fix navbar breakpoint

### DIFF
--- a/app/assets/stylesheets/_bootstrap-default-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-default-overrides.scss
@@ -30,7 +30,6 @@ $jumbotron-button-background-color: #7ab55c;
 $features-section-background-color: #f4f4f4;
 $features-section-border-color: #ddd;
 
-
 // BRAND COLORS
 $white: #ffffff;
 $lightgrey: #F5F5F6;

--- a/app/assets/stylesheets/hyku_knapsack/application.scss
+++ b/app/assets/stylesheets/hyku_knapsack/application.scss
@@ -1,5 +1,6 @@
 @import "adl-variables";
 @import "../adl-overrides/*";
+@import "_bootstrap-default-overrides"
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.


### PR DESCRIPTION
This commit will move the `bootstrap-default-overrides.scss` file to the root of the `app/assets/stylesheets` directory and import it directly.

![navbar](https://github.com/scientist-softserv/adventist_knapsack/assets/19597776/0a3a421d-daa7-4410-b850-bddde6f79692)
