### PR TITLE
Create homepage_controller_decorator.rb

### DIFF
--- a/app/controllers/hyrax/homepage_controller_decorator.rb
+++ b/app/controllers/hyrax/homepage_controller_decorator.rb
@@ -1,18 +1,49 @@
 # frozen_string_literal: true
 
+# OVERRIDE Hyku 5 to add homepage about blocks
 module Hyrax
   module HomepageControllerDecorator
 
     def index
+      # BEGIN copy Hyrax prime's Hyrax::HomepageController#index
       @presenter = presenter_class.new(current_ability, collections)
       @featured_researcher = ContentBlock.for(:researcher)
       @marketing_text = ContentBlock.for(:marketing)
       @featured_work_list = FeaturedWorkList.new
       @announcement_text = ContentBlock.for(:announcement)
+      # OVERRIDE Hyku 5 to add homepage about blocks
       @homepage_about_section_heading = ContentBlock.for(:homepage_about_section_heading)
       @homepage_about_section_content = ContentBlock.for(:homepage_about_section_content)
+      # END OVERRIDE
+      
       recent
+      # END copy
+
+      # BEGIN OVERRIDE
+      # What follows is Hyku specific overrides
+      @home_text = ContentBlock.for(:home_text) # hyrax v3.5.0 added @home_text - Adding Themes
+      @featured_collection_list = FeaturedCollectionList.new # OVERRIDE here to add featured collection list
+
+      ir_counts if home_page_theme == 'institutional_repository'
+
+      (@response, @document_list) = search_results(params)
+
+      respond_to do |format|
+        format.html { store_preferred_view }
+        format.rss  { render layout: false }
+        format.atom { render layout: false }
+        format.json do
+          @presenter = Blacklight::JsonPresenter.new(@response,
+                                                     @document_list,
+                                                     facets_from_request,
+                                                     blacklight_config)
+        end
+        additional_response_formats(format)
+        document_export_formats(format)
+      end
     end
+
+
   end
 end
 

--- a/app/controllers/hyrax/homepage_controller_decorator.rb
+++ b/app/controllers/hyrax/homepage_controller_decorator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module HomepageControllerDecorator
+
+    def index
+      @presenter = presenter_class.new(current_ability, collections)
+      @featured_researcher = ContentBlock.for(:researcher)
+      @marketing_text = ContentBlock.for(:marketing)
+      @featured_work_list = FeaturedWorkList.new
+      @announcement_text = ContentBlock.for(:announcement)
+      @homepage_about_section_heading = ContentBlock.for(:homepage_about_section_heading)
+      @homepage_about_section_content = ContentBlock.for(:homepage_about_section_content)
+      recent
+    end
+  end
+end
+
+Hyrax::HomepageController.prepend(Hyrax::HomepageControllerDecorator)


### PR DESCRIPTION
In staging, we noticed that we were missing the content blocks from the index page. This bit of code must've been missed in the original knapsack: https://github.com/scientist-softserv/adventist-dl/blob/main/app/controllers/hyrax/homepage_controller.rb#L15-L24


