### PR TITLE
Restore sort by relevance for adventist

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -108,6 +108,11 @@ CatalogController.configure_blacklight do |config|
     config.sort_fields.delete(key)
   end
 
+  def self.uploaded_field
+    ActiveFedora.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date)
+  end
+
+  config.add_sort_field "score desc, #{uploaded_field} desc", label: "Relevance"
   # TODO: replace CatalogController.title_field to return 'title_ssi'
   config.add_sort_field "title_ssi asc", label: "Title"
   # TODO: replace CatalogController.creator_field to return 'creator_ssi'


### PR DESCRIPTION
This commit brings back the implementation that allows the catalog search to sort by relevance.

Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/129

## BEFORE
![image](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/99e56efe-e480-4d12-9487-31437cd5abc6)


## AFTER
![image](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/7fad3e63-1d49-4513-a32e-1088a8b0cce6)

