### PR TITLE
⚙️ Set ENVs at APP level to propagate to WEB and WORKER

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,20 @@ x-app: &app
       APP_PATH: ./hyrax-webapp
   image: ghcr.io/scientist-softserv/adventist_knapsack:${TAG:-latest}
   environment:
-    # This line is what makes the knapsack include use the local code instead of the remote gem
-    - BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
-    - BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
+    - AUXILIARY_QUEUE_TENANTS="sdapi" # This line is what makes the knapsack include use the local code instead of the remote gem
+    - AWS_REGION=us-east-1
+    - AWS_S3_BUCKET=space-stone-production-preprocessedbucketf21466dd-15sun4xy658nh
     - BUNDLE_BUNDLER_INJECT__GEM_PATH=/app/samvera/bundler.d
+    - BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
+    - BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera # This line is what makes the knapsack include use the local code instead of the remote gem
+    - FITS_SERVLET_URL=http://fits:8080/fits
+    - GOOD_JOB_CLEANUP_DISCARDED_JOBS=false
+    - GOOD_JOB_CLEANUP_INTERVAL_SECONDS=86400
+    - GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO=604800
     - HYRAX_ACTIVE_JOB_QUEUE=good_job
+    - VIRTUAL_HOST=.hyku.test
+    - VIRTUAL_PORT=3000
+
   volumes:
     - node_modules:/app/samvera/hyrax-webapp/node_modules:cached
     - uploads:/app/samvera/hyrax-webapp/public/uploads:cached
@@ -73,21 +82,6 @@ services:
       service: web
     # Uncomment command to access container with out starting bin/web. Useful for debugging or updating Gemfile.lock
     # command: sleep infinity
-    environment:
-      # This line is what makes the knapsack include use the local code instead of the remote gem
-      - AUXILIARY_QUEUE_TENANTS="sdapi"
-      - AWS_S3_BUCKET=space-stone-production-preprocessedbucketf21466dd-15sun4xy658nh
-      - AWS_REGION=us-east-1
-      - BUNDLE_BUNDLER_INJECT__GEM_PATH=/app/samvera/bundler.d
-      - BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
-      - BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
-      - FITS_SERVLET_URL=http://fits:8080/fits
-      - GOOD_JOB_CLEANUP_DISCARDED_JOBS=false
-      - GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO=604800
-      - GOOD_JOB_CLEANUP_INTERVAL_SECONDS=86400
-      - HYRAX_ACTIVE_JOB_QUEUE=good_job
-      - VIRTUAL_PORT=3000
-      - VIRTUAL_HOST=.hyku.test
 
   worker:
     <<: *app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,13 @@ services:
       file: hyrax-webapp/docker-compose.yml
       service: fcrepo
 
+  fits:
+    image: harvardlts/fitsservlet_container:1.5.0
+    ports:
+      - 9090:8080
+    networks:
+      internal:
+
   db:
     extends:
       file: hyrax-webapp/docker-compose.yml


### PR DESCRIPTION
Adds env to app so that all services receive the variables. Also add a fits service to docker-compose.yml to remedy error: 

<img width="901" alt="image" src="https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/2d165e7a-d226-49f1-ade6-ce4d483f6252">

This prevents CharacterizeJob from running, making width and height nil. 