### PR TITLE
TEMPORARY hot fix of staging redirect issue

### DIFF
--- a/app/helpers/hyku_knapsack/application_helper.rb
+++ b/app/helpers/hyku_knapsack/application_helper.rb
@@ -24,6 +24,7 @@ module HykuKnapsack
     # @param request [ActionDispatch::Request]
     def generate_work_url(doc, request)
       url = super
+      url = url.gsub('adventist-knapsack-staging.notch8.cloud/', 's2.adventistdigitallibrary.org/')
       return url if request.params[:q].blank?
 
       key = doc.any_highlighting? ? 'parent_query' : 'query'


### PR DESCRIPTION
Staging is oddly redirecting urls to the old staging site, when using the catalog search.

Convo:
- https://assaydepot.slack.com/archives/C0311DN2YCA/p1713315845486939

