### PR TITLE
update css to hide badges and tags

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -452,13 +452,6 @@ body.public-facing {
     background-color: $darkyellow;
   }
 
-  //hides the visibility badge on top of work show page & hides the "user collection" labels in search results
-  .panel-default .panel-heading small span.label,
-  .search-results-title-row span.label,
-  .hyc-title span.label {
-    display: none;
-  }
-
   //ADD WORK PAGE
 
   .dashboard .panel {
@@ -488,3 +481,13 @@ body.public-facing {
   background: yellow;
   font-weight: 700;
 }
+
+//hides the visibility badge on top of work show page & hides the "user collection" labels in search results
+.panel-default .panel-heading small span.label,
+.search-results-title-row span.label,
+.hyc-title span.label, 
+.work-type span.label, 
+.collection-title-row-content span.label {
+  display: none;
+}
+  


### PR DESCRIPTION
Displaying badges like "public" on the work and show pages was intentionally removed before the Knapsack cutover. Post cutover they were reintroduced. The client requests that they be removed again.

Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/152

## BEFORE
![Screenshot 2024-04-18 at 15-16-25 cat scan](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/40c9fdd8-7dba-4c46-b92f-07b0f6212d6e)


![Screenshot 2024-04-18 at 15-12-52 collection test __ Hyku](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/2ef3cde5-f23a-4a2d-9e30-0d4e00abd7e9)

## AFTER
![Screenshot 2024-04-18 at 15-16-10 cat scan](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/f0699b9c-4380-4475-a763-ca540fcaae45)

![Screenshot 2024-04-18 at 15-15-53 collection test __ Hyku](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/8611ad3f-3120-4ff4-986c-e975114a7ba3)
