### PR TITLE
:bug: Update class reference to hide title badges

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -486,7 +486,7 @@ body.public-facing {
 .panel-default .panel-heading small span.label,
 .search-results-title-row span.label,
 .hyc-title span.label, 
-.work-type span.label, 
+.title-with-badges span.label, 
 .collection-title-row-content span.label {
   display: none;
 }


### PR DESCRIPTION
We need a more specific class reference. We only want to hide the tags and badges from the titles.

ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/152

# BEFORE

![Screenshot 2024-04-22 at 12 42 01 PM](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/99d05426-927e-49a5-96d0-97acc5eac35a)




# AFTER

![Screenshot 2024-04-22 at 10-20-35 cat scan](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/8b8e1c6f-8c05-4272-bd7e-2549b9ec8180)
![Screenshot 2024-04-22 at 10-20-50 Works](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/2de59126-14a9-4e22-91f7-124f83c727fc)
![Screenshot 2024-04-22 at 10-21-54 cats __ Hyku](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/9f192884-7dac-4291-96f8-b02b22d81bed)
![Screenshot 2024-04-22 at 10-21-39 Collections](https://github.com/scientist-softserv/adventist_knapsack/assets/10081604/a39704bf-c0f4-4bbd-98a8-55fef500c629)
