### PR TITLE
🐛 Add safe navigation operator for nil mime types

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
@@ -32,7 +32,7 @@ module HykuKnapsack
         # Our current presenter is a IiifManifestPresenter, which doesn't have the file_set_presenters we need.
         # So we create a Hyrax presenter for the model, and use that to get the file_set_presenters.
         hyrax_presenter = "Hyrax::#{model}Presenter".constantize.new(presenter, presenter.ability)
-        file_set_presenters = hyrax_presenter.file_set_presenters.reject { |fsp| fsp.mime_type.include?('image') }
+        file_set_presenters = hyrax_presenter.file_set_presenters.reject { |fsp| fsp.mime_type&.include?('image') }
 
         file_set_presenters.map do |fsp|
           {


### PR DESCRIPTION
Some times we're seeing a file set come in with a nil mime type because something went wrong.  This would break the viewer because we get a `NoMethodError` when trying to call `include?`.  Adding the lonely operator here should prevent that from happening.
