### PR TITLE
🐛 Fix BOM bug round 2

### DIFF
--- a/app/models/bulkrax/csv_entry_decorator.rb
+++ b/app/models/bulkrax/csv_entry_decorator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# OVERRIDE BULKRAX v5.4.1 to add BOM encoding support when reading CSVs
+
+require 'csv'
+
+module Bulkrax
+  module CsvEntryDecorator
+    module ClassMethods
+      def read_data(path)
+        raise StandardError, 'CSV path empty' if path.blank?
+        options = {
+          headers: true,
+          header_converters: ->(h) { h.to_s.strip.to_sym },
+          encoding: 'bom|utf-8'
+        }.merge(csv_read_data_options)
+
+        results = CSV.read(path, **options)
+        csv_wrapper_class.new(results)
+      end
+    end
+  end
+end
+
+Bulkrax::CsvEntry.singleton_class.prepend(Bulkrax::CsvEntryDecorator::ClassMethods)

--- a/app/parsers/bulkrax/csv_parser_decorator.rb
+++ b/app/parsers/bulkrax/csv_parser_decorator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# OVERRIDE BULKRAX v5.4.1 to add BOM support when parsing values
+
+module Bulkrax
+  module CsvParserDecorator
+    def missing_elements(record)
+      keys_from_record = extract_keys_from_record(record)
+      keys = collect_keys_from_mapping(keys_from_record)
+      required_elements_str = normalize_elements(required_elements)
+
+      identify_missing_elements(required_elements_str, keys)
+    end
+
+    private
+
+      def extract_keys_from_record(record)
+        keys = record.reject { |_, v| v.blank? }
+                     .keys
+                     .compact
+                     .uniq
+                     .map(&:to_s)
+                     .map(&:strip)
+                     .map { |k| Bulkrax.normalize_string(k) }
+        keys_without_numbers(keys)
+      end
+
+      def collect_keys_from_mapping(keys_from_record)
+        keys = []
+        importerexporter.mapping.stringify_keys.each do |k, v|
+          Array.wrap(v['from']).each do |vf|
+            vf_str = Bulkrax.normalize_string(vf.to_s.strip)
+            keys << k.to_s.strip if keys_from_record.include?(vf_str)
+          end
+        end
+        keys.uniq.map(&:to_s).map(&:strip).map { |k| Bulkrax.normalize_string(k) }
+      end
+
+      def normalize_elements(elements)
+        elements.map(&:to_s).map(&:strip).map { |k| Bulkrax.normalize_string(k) }
+      end
+
+      def identify_missing_elements(required_elements, keys)
+        required_elements - keys
+      end
+  end
+end
+
+Bulkrax::CsvParser.prepend(Bulkrax::CsvParserDecorator)


### PR DESCRIPTION
Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/680

The client would import CSVs that had identifier columns, but the importer would still fail with "Missing at least one required element, missing element(s) are: identifier"

This commit utilizes the BOM method, previously created, and adds bom support for reading CSVs.

### Sample File
Download from [here](https://we.tl/t-GU29JxaNAD)

## BEFORE
<details> 

![image](https://github.com/user-attachments/assets/d260b08e-6f44-4fa5-96d7-5d2502508e36)

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/31ec87b3-1a6f-4dd7-a171-bfc81707c710">

</details> 

## AFTER
<details> 

![Screenshot 2024-07-11 at 14-42-56 Index Importer __ Hyku](https://github.com/user-attachments/assets/e1c01efc-8091-4527-af41-26fcb14e5ad1)
![Screenshot 2024-07-11 at 14-44-13 Show Importer __ Hyku](https://github.com/user-attachments/assets/b0fadb5d-6c23-4033-8616-827f8ae08e53)
![Screenshot 2024-07-11 at 14-44-20 Image Panorama of Union College Lincoln Nebraska ID p006173_panorama_of_union_college_lincoln_nebraska Hyku](https://github.com/user-attachments/assets/6f6d1d53-7d40-4cf3-8213-a9f5cd1c5324)

</details>

### TODO

- [x] ~contribute back to bulkrax~ [Not needed](https://github.com/samvera/bulkrax/pull/965#issuecomment-2224061106)


