### PR TITLE
Update the cert-manager cluster-issuer to wildcard-issuer

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -53,7 +53,7 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
+    cert-manager.io/cluster-issuer: wildcard-issuer
   tls:
     - hosts:
         - '*.s2.adventistdigitallibrary.org'


### PR DESCRIPTION
# Story

Update the staging cluster issuer in the helm deploy values file to `wildcard-issuer`
This is live on production and persists the changes for the next deployment to staging.

- #699 

# Expected Behavior Before Changes
cert manager is not renewing certificates for staging automatically

# Expected Behavior After Changes
cert manager is now renews certificates for staging automatically

# Screenshots / Video

<details>
<summary>Cert renewed</summary>
<img width="1496" alt="Screenshot 2024-07-19 at 09 27 05" src="https://github.com/user-attachments/assets/6f4ab022-a464-4f5d-af79-51cbb197929e">

</details>
