### PR TITLE
Fix manifest

### DIFF
--- a/app/presenters/adl/iiif_manifest_presenter_factory_decorator.rb
+++ b/app/presenters/adl/iiif_manifest_presenter_factory_decorator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# OVERRIDE IiifPrint v3.0.1 to check has_model instead of hydra_model. 
+# Hyrax.config.curation_concerns does not include "Resource"
+
+module Adl
+  module IiifManifestPresenterFactoryDecorator
+    # This will override Hyrax::IiifManifestPresenter::Factory#build and introducing
+    # the expected behavior:
+    # - child work images show as canvases in the parent work manifest
+    # - child work images show in the uv on the parent show page
+    # - still create the manifest if the parent work has images attached but the child works do not
+    def build
+      ids.map do |id|
+        solr_doc = load_docs.find { |doc| doc.id == id }
+        next unless solr_doc
+
+        if solr_doc.file_set?
+          presenter_class.for(solr_doc)
+        # OVERRIDE IiifPrint: elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
+        elsif Hyrax.config.curation_concerns.include?(solr_doc["has_model_ssim"].first.constantize)
+          # look up file set ids and loop through those
+          file_set_docs = load_file_set_docs(solr_doc.try(:member_ids) || solr_doc.try(:[], 'member_ids_ssim'))
+          file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
+        end
+      end.flatten.compact
+    end
+  end
+end
+
+Hyrax::IiifManifestPresenter::Factory.prepend(Adl::IiifManifestPresenterFactoryDecorator)

--- a/lib/iiif_manifest/manifest_builder/canvas_builder_factory_decorator.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder_factory_decorator.rb
@@ -8,7 +8,7 @@ module IIIFManifest
       def from(work)
         composite_builder.new(
           *file_set_presenters(work).map do |presenter|
-            next if presenter&.label&.downcase&.end_with?(HykuKnapsack::Engine::THUMBNAIL_FILE_SUFFIX) || !presenter.image?
+            next if presenter.solr_document['original_filename_ssi'].downcase.end_with?(HykuKnapsack::Engine::THUMBNAIL_FILE_SUFFIX) || !presenter.image?
             canvas_builder_factory.new(presenter, work)
           end
         )


### PR DESCRIPTION
# Story

This fixes issues preventing universal viewer from building the manifest with the items.

Two issues were found:
1) `Hyrax.config.curation_concerns` does not include the Resource objects. It is comparing to `solr_doc.hydra_model` which is the full work type name so the work types never match for resources.  This is a concerning bug because it comes from IiifPrint, and it is logical that it would affect any resources in a valkyrized app using IiifPrint. 
2) The logic to prevent the tn.jpg files from displaying in the viewer broke because the presenter no longer responds to `label`.

Refs https://github.com/scientist-softserv/adventist_knapsack/issues/730

# Expected Behavior Before Changes

Manifest had no items so it was empty.

# Expected Behavior After Changes

Manifest includes image files of both file sets and child works.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2024-08-06 at 4 20 37 PM](https://github.com/user-attachments/assets/0b8ed05c-cde7-4734-a448-3ad5806e7e17)

</details>

# Notes
