### PR TITLE
Fix splitting for generic work and image resoures

### DIFF
--- a/app/models/generic_work_resource_decorator.rb
+++ b/app/models/generic_work_resource_decorator.rb
@@ -2,3 +2,10 @@
 
 GenericWorkResource.include Hyrax::Schema(:slug_metadata)
 GenericWorkResource.include(SlugBugValkyrie)
+GenericWorkResource.prepend(IiifPrint.model_configuration(
+                            pdf_split_child_model: GenericWorkResource,
+                            pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
+                            derivative_service_plugins: [
+                              IiifPrint::TextExtractionDerivativeService
+                            ]
+                          ))

--- a/app/models/image_resource_decorator.rb
+++ b/app/models/image_resource_decorator.rb
@@ -2,3 +2,10 @@
 
 ImageResource.include Hyrax::Schema(:slug_metadata)
 ImageResource.include(SlugBugValkyrie)
+ImageResource.prepend(IiifPrint.model_configuration(
+                      pdf_split_child_model: ImageResource,
+                      pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
+                      derivative_service_plugins: [
+                        IiifPrint::TextExtractionDerivativeService
+                      ]
+                    ))


### PR DESCRIPTION
# Story

Refs 
- https://github.com/scientist-softserv/adventist_knapsack/issues/774

# Expected Behavior Before Changes

PDF files did not split for Image & GenericWork resources.

# Expected Behavior After Changes

PDF files split into pages of the same model as the parent.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2024-08-27 at 5 03 09 PM](https://github.com/user-attachments/assets/f067704c-a29c-4cde-8085-7ebc552bd84d)

</details>

# Notes
