### PR TITLE
Do not split if pdfjs flipper on

### DIFF
--- a/app/jobs/iiif_print/child_works_from_pdf_job_decorator.rb
+++ b/app/jobs/iiif_print/child_works_from_pdf_job_decorator.rb
@@ -2,6 +2,8 @@
 
 # OVERRIDE: Overriding entire job temporarily, pending cleanup via
 # https://github.com/scientist-softserv/adventist_knapsack/issues/728
+# OVERRIDE to end job based on pdfjs/uv flipper before doing anything
+# so we don't get job errors
 require 'iiif_print/jobs/application_job'
 
 module IiifPrint
@@ -15,6 +17,7 @@ module IiifPrint
     # @param admin_set_id: [<String>]
     # rubocop:disable Metrics/MethodLength
     def perform(id, pdf_paths, user, admin_set_id, *)
+      return unless IiifPrint::TenantConfig.use_iiif_print?
       candidate_for_parency = IiifPrint.find_by(id:)
 
       ##

--- a/app/services/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/app/services/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -11,6 +11,7 @@ module IiifPrint
       # @return [TrueClass] when we should be splitting this path.
       # @return [TrueClass] when we should not be splitting this path.
       def self.split_this?(path:, suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES)
+        return false unless IiifPrint::TenantConfig.use_iiif_print?
         suffixes.none? { |suffix| path.downcase.end_with?(suffix) }
       end
 

--- a/app/services/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/app/services/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -11,7 +11,6 @@ module IiifPrint
       # @return [TrueClass] when we should be splitting this path.
       # @return [TrueClass] when we should not be splitting this path.
       def self.split_this?(path:, suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES)
-        return false unless IiifPrint::TenantConfig.use_iiif_print?
         suffixes.none? { |suffix| path.downcase.end_with?(suffix) }
       end
 


### PR DESCRIPTION
# Story

Refs
- https://github.com/scientist-softserv/adventist_knapsack/issues/779

# Expected Behavior Before Changes

If the original file has a .pdf suffix, IiifPrint split will be attempted.

# Expected Behavior After Changes

PDFjs/UV feature flipper `use_iiif_print` will bypass splitting when set to PDFjs.

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
Adding the flag to the splitter allowed the jobs to run and fail because no images were split. Instead the flag was moved to the beginning of the job itself, allowing the process to stop before submitting any further jobs.