### PR TITLE
🎁 Hide User Collection and Public tags

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -511,9 +511,9 @@ body.works-show.adl_show {
 
 //hides the visibility badge on top of work show page & hides the "user collection" labels in search results
 .panel-default .panel-heading small span.label,
-.search-results-title-row span.label,
+.search-results-title-row span.badge,
 .hyc-title span.label,
 .title-with-badges span.label,
-.collection-title-row-content span.label {
+.collection-title-row-content span.badge {
   display: none;
 }


### PR DESCRIPTION
# Story

🎁 Hide User Collection and Public tags

This commit hides the User Collection and Public tags from the public
collection show pages (admin dashbaord) and the catalog search results
page.

Ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/791

# Expected Behavior Before Changes

- `User Collection` and `Public` tags were visible on the collection show page
<img width="1413" alt="Screenshot 2024-09-09 at 1 19 24 PM" src="https://github.com/user-attachments/assets/bd753ffa-300f-402a-a989-dc9b0f5f6ef1">


- `User Collection` and `Public` tags were visible on the catalog search results
<img width="1416" alt="Screenshot 2024-09-09 at 2 04 21 PM" src="https://github.com/user-attachments/assets/ec04ebf7-a14d-44a8-9bd8-87eb8f71aa12">



# Expected Behavior After Changes

- `User collection` and `Public` tags are not visible on the collection show page
<img width="1420" alt="Screenshot 2024-09-09 at 1 55 02 PM" src="https://github.com/user-attachments/assets/2c6ba4c8-34bd-4369-9ff3-728da3fe84b7">

- `User Collection` and `Public` tags are not visible on the catalog search results
<img width="1419" alt="Screenshot 2024-09-09 at 1 59 36 PM" src="https://github.com/user-attachments/assets/3f01a7a4-c77f-4554-86ce-e66b62245304">

# Notes

The acceptance criteria was updated to include the `Public` tags as well as the `User Collection` tags. [Approved by Katharine in Slack](https://assaydepot.slack.com/archives/C0313NJV9PE/p1725913695951139).
