### PR TITLE
🎁 Hides all badges to match parity with prod

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -509,11 +509,11 @@ body.works-show.adl_show {
   max-width: 25%;
 }
 
-//hides the visibility badge on top of work show page & hides the "user collection" labels in search results
-.panel-default .panel-heading small span.label,
+// hides the visibility badge on top of work show page & hides the "user collection" badges in search results
+.panel-default .panel-heading small span.badge,
 .search-results-title-row span.badge,
-.hyc-title span.label,
-.title-with-badges span.label,
+.hyc-title span.badge,
+.title-with-badges span.badge,
 .collection-title-row-content span.badge {
   display: none;
 }


### PR DESCRIPTION
# Story

🎁 Hide User Collection and Public tags

This commit expands on #795 to hides all tags from collection and works show pages. Additional tags were found in staging that will be removed by this commit.

Ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/791

# Expected Behavior Before Changes

- `User Collection` and `Public` tags were visible on collection and works show pages

# Expected Behavior After Changes

- No `User collection` or `Public` are visible

# Notes

The acceptance criteria is to match parity with the production application. There were additional tags found in staging that were removed by this commit.
