### PR TITLE
Update date issued metadata tag label

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -20,7 +20,7 @@
 <%= presenter.attribute_to_html(:remote_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:extent) %>
-<%= presenter.attribute_to_html(:date_issued, label: 'Date Issued') %>
+<%= presenter.attribute_to_html(:date_issued, label: I18n.t('dog_biscuits.fields.date')) %>
 <%= presenter.attribute_to_html(:alt, label: 'Publication GeoCode') %>
 <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
 <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>

--- a/config/locales/dog_biscuits.en.yml
+++ b/config/locales/dog_biscuits.en.yml
@@ -26,7 +26,7 @@ en:
       date_created: Date created
       date_collected: Date collected
       date_copyrighted: Date copyrighted
-      date_issued: Date issued
+      date_issued: Date
       date_of_award: Date of award
       date_published: Publication date
       date_submitted: Date submitted


### PR DESCRIPTION
# Story
Updates metadata tag label for `date_issued` to display 'Date' on show and index pages.


Refs

- #169 

# Expected Behavior Before Changes

Date issued metadata tag displays 'Date issued'

# Expected Behavior After Changes

Date issued metadata tag displays 'Date'

# Screenshots / Video

<details>

## Before

![image](https://github.com/user-attachments/assets/0a6be042-c71f-4b7e-8669-5d8bc3f9299f)

## After

![image](https://github.com/user-attachments/assets/49d6517e-5f6e-4738-9354-c55d25e4dbfd)

</details>

# Notes
