### PR TITLE
🐛 Fix thumbnails not showing for logged out users

### DIFF
--- a/app/models/concerns/hyrax/ability/resource_ability_decorator.rb
+++ b/app/models/concerns/hyrax/ability/resource_ability_decorator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.0.1 to add support for slugs
+
+module Hyrax
+  module Ability
+    module ResourceAbilityDecorator
+      def resource_abilities
+        if admin?
+          can [:manage], ::Hyrax::Resource
+        else
+          can [:edit, :update, :destroy], ::Hyrax::Resource do |res|
+            test_edit(res.to_param) # #to_param checks for slug or id
+          end
+          can :read, ::Hyrax::Resource do |res|
+            test_read(res.to_param) # #to_param checks for slug or id
+          end
+        end
+      end
+    end
+  end
+end
+
+Hyrax::Ability::ResourceAbility.prepend(Hyrax::Ability::ResourceAbilityDecorator)


### PR DESCRIPTION
This commit overrides an ability mixin to check for either the slugs or id so when it's used downstream, we can ensure that the thumbnails are displaying correctly due to the permissions being set correctly.

<img width="688" alt="image" src="https://github.com/user-attachments/assets/4b8ea0ec-d440-43a7-a8d9-e68ae3954fef">
