### PR TITLE
Blank metadata fields

### DIFF
--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -15,10 +15,7 @@ Hyrax::Renderers::AttributeRenderer.class_eval do
   def render
     markup = ''
 
-    # This is a temporary solution for prohibiting blank metadata fields from being displayed.
-    # Many fields with no assigned values are returning as [""] causing the field to render.
-    # TODO: Find the root cause of this issue are return the following line to its original state.
-    return markup if Array.wrap(values).first.blank? && !options[:include_empty]
+    return markup if values.blank? && !options[:include_empty]
     markup << %(<div class='metadata-group md-#{field}'><dt>#{label}</dt>\n<dd><ul class='tabular'>)
     attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
     Array(values).each do |value|

--- a/config/metadata/adl_metadata.yaml
+++ b/config/metadata/adl_metadata.yaml
@@ -67,7 +67,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - preflabel_tesim
+    - preflabel_tesi
     - preflabel_si
     predicate: http://www.w3.org/2004/02/skos/core#prefLabel
   altlabel:
@@ -84,7 +84,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - rdfs_label_tesim
+    - rdfs_label_tesi
     predicate: http://www.w3.org/2000/01/rdf-schema#label
   # seems to be just a composite field?
   date:
@@ -314,8 +314,8 @@ attributes:
       required: true
       primary: true
     index_keys:
-    - rights_statement_tesim
-    - rights_statement_sim
+    - rights_statement_tesi
+    - rights_statement_si
     predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
@@ -371,7 +371,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - on_behalf_of_ssim
+    - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
   state:
     type: string
@@ -385,5 +385,5 @@ attributes:
     form:
       primary: false
     index_keys:
-    - proxy_depositor_ssim
+    - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -25,8 +25,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available
   date_published:
     type: string
@@ -34,8 +34,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_published_tesim
-    - date_published_sim
+    - date_published_tesi
+    - date_published_si
     predicate: http://schema.org/datePublished
   date_submitted:
     type: string
@@ -43,8 +43,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_submitted_tesim
-    - date_submitted_sim
+    - date_submitted_tesi
+    - date_submitted_si
     predicate: http://london.ac.uk/ontologies/terms#dateSubmitted
   date_accepted:
     type: string
@@ -52,8 +52,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_accepted_tesim
-    - date_accepted_sim
+    - date_accepted_tesi
+    - date_accepted_si
     predicate: http://purl.org/dc/terms/dateAccepted
   date_issued:
     type: date_time
@@ -61,8 +61,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_issued_tesim
-    - date_issued_sim
+    - date_issued_tesi
+    - date_issued_si
     predicate: http://purl.org/dc/terms/issued
   doi:
     type: string
@@ -95,7 +95,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - issue_number_tesim
+    - issue_number_tesi
     predicate: http://schema.org/issueNumber
   location:
     type: string
@@ -171,8 +171,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - publication_status_tesim
-    - publication_status_sim
+    - publication_status_tesi
+    - publication_status_si
     predicate: http://purl.org/ontology/bibo/status
   place_of_publication:
     type: string
@@ -221,7 +221,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - preflabel_tesim
+    - preflabel_tesi
     - preflabel_si
     predicate: http://www.w3.org/2004/02/skos/core#prefLabel
   altlabel:
@@ -425,8 +425,8 @@ attributes:
       required: false
       primary: false
     index_keys:
-    - rights_statement_tesim
-    - rights_statement_sim
+    - rights_statement_tesi
+    - rights_statement_si
     predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
@@ -482,7 +482,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - on_behalf_of_ssim
+    - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
   state:
     type: string
@@ -496,5 +496,5 @@ attributes:
     form:
       primary: false
     index_keys:
-    - proxy_depositor_ssim
+    - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/conference_item_resource.yaml
+++ b/config/metadata/conference_item_resource.yaml
@@ -28,8 +28,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_published_tesim
-    - date_published_sim
+    - date_published_tesi
+    - date_published_si
     predicate: http://schema.org/datePublished
   keyword:
     type: string
@@ -46,8 +46,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available
   date_submitted:
     type: string
@@ -55,8 +55,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_submitted_tesim
-    - date_submitted_sim
+    - date_submitted_tesi
+    - date_submitted_si
     predicate: http://london.ac.uk/ontologies/terms#dateSubmitted
   date_accepted:
     type: string
@@ -64,8 +64,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_accepted_tesim
-    - date_accepted_sim
+    - date_accepted_tesi
+    - date_accepted_si
     predicate: http://purl.org/dc/terms/dateAccepted
   editor:
     type: string
@@ -82,8 +82,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - event_date_tesim
-    - event_date_sim
+    - event_date_tesi
+    - event_date_si
     predicate: http://rs.tdwg.org/dwc/terms/eventDate
   isbn:
     type: string
@@ -141,8 +141,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - publication_status_tesim
-    - publication_status_sim
+    - publication_status_tesi
+    - publication_status_si
     predicate: http://purl.org/ontology/bibo/status
   presented_at:
     type: string

--- a/config/metadata/dataset_resource.yaml
+++ b/config/metadata/dataset_resource.yaml
@@ -28,8 +28,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_published_tesim
-    - date_published_sim
+    - date_published_tesi
+    - date_published_si
     predicate: http://schema.org/datePublished
   resource_type_general:
     type: string
@@ -45,8 +45,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_collected_tesim
-    - date_collected_sim
+    - date_collected_tesi
+    - date_collected_si
     predicate: http://purl.org/spar/fabio/hasDateCollected
   date_issued:
     type: date_time
@@ -54,8 +54,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_issued_tesim
-    - date_issued_sim
+    - date_issued_tesi
+    - date_issued_si
     predicate: http://purl.org/dc/terms/issued
   keyword:
     type: string
@@ -96,8 +96,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_accepted_tesim
-    - date_accepted_sim
+    - date_accepted_tesi
+    - date_accepted_si
     predicate: http://purl.org/dc/terms/dateAccepted
   date_copyrighted:
     type: date_time
@@ -105,8 +105,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_copyrighted_tesim
-    - date_copyrighted_sim
+    - date_copyrighted_tesi
+    - date_copyrighted_si
     predicate: http://purl.org/dc/terms/dateCopyrighted
   content_version:
     type: string
@@ -123,8 +123,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available
   date_submitted:
     type: string
@@ -132,8 +132,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_submitted_tesim
-    - date_submitted_sim
+    - date_submitted_tesi
+    - date_submitted_si
     predicate: http://london.ac.uk/ontologies/terms#dateSubmitted
   for_indexing:
     type: string
@@ -166,7 +166,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - number_of_downloads_tesim
+    - number_of_downloads_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#numberOfDownloads
   readme:
     type: string
@@ -174,7 +174,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - readme_tesim
+    - readme_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#readme
   requestor_email:
     type: string
@@ -199,8 +199,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_updated_tesim
-    - date_updated_sim
+    - date_updated_tesi
+    - date_updated_si
     predicate: http://schema.org/dateModified
   last_access:
     type: date_time
@@ -208,5 +208,5 @@ attributes:
     form:
       primary: false
     index_keys:
-    - last_access_tesim
+    - last_access_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#lastAccess

--- a/config/metadata/exam_paper_resource.yaml
+++ b/config/metadata/exam_paper_resource.yaml
@@ -63,6 +63,6 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available

--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -248,8 +248,8 @@ attributes:
       required: true
       primary: true
     index_keys:
-    - rights_statement_tesim
-    - rights_statement_sim
+    - rights_statement_tesi
+    - rights_statement_si
     predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
@@ -305,7 +305,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - on_behalf_of_ssim
+    - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
   state:
     type: string
@@ -319,5 +319,5 @@ attributes:
     form:
       primary: false
     index_keys:
-    - proxy_depositor_ssim
+    - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/image_resource.yaml
+++ b/config/metadata/image_resource.yaml
@@ -256,8 +256,8 @@ attributes:
       required: true
       primary: true
     index_keys:
-    - rights_statement_tesim
-    - rights_statement_sim
+    - rights_statement_tesi
+    - rights_statement_si
     predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
@@ -313,7 +313,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - on_behalf_of_ssim
+    - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
   state:
     type: string
@@ -327,5 +327,5 @@ attributes:
     form:
       primary: false
     index_keys:
-    - proxy_depositor_ssim
+    - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/journal_article_resource.yaml
+++ b/config/metadata/journal_article_resource.yaml
@@ -28,8 +28,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_published_tesim
-    - date_published_sim
+    - date_published_tesi
+    - date_published_si
     predicate: http://schema.org/datePublished
   date_issued:
     type: date_time
@@ -37,8 +37,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_issued_tesim
-    - date_issued_sim
+    - date_issued_tesi
+    - date_issued_si
     predicate: http://purl.org/dc/terms/issued
   keyword:
     type: string
@@ -71,8 +71,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available
   date_submitted:
     type: string
@@ -80,8 +80,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_submitted_tesim
-    - date_submitted_sim
+    - date_submitted_tesi
+    - date_submitted_si
     predicate: http://london.ac.uk/ontologies/terms#dateSubmitted
   date_accepted:
     type: string
@@ -89,8 +89,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_accepted_tesim
-    - date_accepted_sim
+    - date_accepted_tesi
+    - date_accepted_si
     predicate: http://purl.org/dc/terms/dateAccepted
   orcid:
     type: string
@@ -115,8 +115,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - publication_status_tesim
-    - publication_status_sim
+    - publication_status_tesi
+    - publication_status_si
     predicate: http://purl.org/ontology/bibo/status
   refereed:
     type: string
@@ -133,7 +133,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - issue_number_tesim
+    - issue_number_tesi
     predicate: http://schema.org/issueNumber
   official_url:
     type: string

--- a/config/metadata/published_work_resource.yaml
+++ b/config/metadata/published_work_resource.yaml
@@ -28,8 +28,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_published_tesim
-    - date_published_sim
+    - date_published_tesi
+    - date_published_si
     predicate: http://schema.org/datePublished
   date_issued:
     type: date_time
@@ -37,8 +37,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_issued_tesim
-    - date_issued_sim
+    - date_issued_tesi
+    - date_issued_si
     predicate: http://purl.org/dc/terms/issued
   keyword:
     type: string
@@ -71,8 +71,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_available_tesim
-    - date_available_sim
+    - date_available_tesi
+    - date_available_si
     predicate: http://purl.org/dc/terms/available
   date_submitted:
     type: string
@@ -80,8 +80,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_submitted_tesim
-    - date_submitted_sim
+    - date_submitted_tesi
+    - date_submitted_si
     predicate: http://london.ac.uk/ontologies/terms#dateSubmitted
   issue_number:
     type: string
@@ -89,7 +89,7 @@ attributes:
     form:
       primary: false
     index_keys:
-    - issue_number_tesim
+    - issue_number_tesi
     predicate: http://schema.org/issueNumber
   edition:
     type: string
@@ -129,8 +129,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_accepted_tesim
-    - date_accepted_sim
+    - date_accepted_tesi
+    - date_accepted_si
     predicate: http://purl.org/dc/terms/dateAccepted
   publication_status:
     type: string
@@ -138,8 +138,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - publication_status_tesim
-    - publication_status_sim
+    - publication_status_tesi
+    - publication_status_si
     predicate: http://purl.org/ontology/bibo/status
   refereed:
     type: string

--- a/config/metadata/thesis_resource.yaml
+++ b/config/metadata/thesis_resource.yaml
@@ -28,8 +28,8 @@ attributes:
     form:
       primary: false
     index_keys:
-    - date_issued_tesim
-    - date_issued_sim
+    - date_issued_tesi
+    - date_issued_si
     predicate: http://purl.org/dc/terms/issued
   keyword:
     type: string


### PR DESCRIPTION
# Story

Blank metadata properties should not display on the show page for collections or works.

Refs
- https://github.com/scientist-softserv/adventist_knapsack/issues/771

# Expected Behavior Before Changes

Some metadata fields that did not have content were rending on the catalog page, the works show page, and the collection show page.

# Expected Behavior After Changes

Only metadata fields that have content will render.

# Screenshots / Video
- Catalog page
<img width="1557" alt="Screenshot 2024-09-19 at 3 48 12 PM" src="https://github.com/user-attachments/assets/9311be82-a08b-4b95-9b4e-0ae5674e317d">
- Works show page
![image](https://github.com/user-attachments/assets/061445ba-aced-4da7-8ff0-71b5c93a6da3)
- Collection show page
![image](https://github.com/user-attachments/assets/100b9c65-7f16-4c8b-84bd-c93b5a76b49f)
