### PR TITLE
🎁 Add snippets to catalog search

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -61,6 +61,7 @@ CatalogController.configure_blacklight do |config|
     { prop => CatalogController.send(:index_options, prop, DogBiscuits.config.property_mappings[prop]) }
   end
   CatalogController.send(:add_index_field, config, index_props)
+  config.add_index_field 'all_text_tsimv', label: "Item contents", highlight: true, helper_method: :render_ocr_snippets, if: :query_present?
 
   config.search_fields.delete('all_fields')
   config.add_search_field('all_fields',


### PR DESCRIPTION
This commit will add the index field for snippets onto the CatalogControllerDecorator so ADL can see snippets.  We had to add this because we remove all the add index fields prior and only add select ones.  That means we have to manually add this one.

Ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/769

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/6d260506-0645-4ebf-ad4d-70b31c4ac2e7">

