### PR TITLE
🐛 Change indexing for issue_number

### DIFF
--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -110,7 +110,7 @@ attributes:
       primary: false
       multiple: true
     index_keys:
-    - issue_number_isim
+    - issue_number_tesim
     predicate: http://schema.org/issueNumber
   location:
     type: string


### PR DESCRIPTION
Originally changed because it matches Adventist prior to Valkyrie, but it seems to be causing issues so I'm changing it to _tesim.

Ref https://github.com/scientist-softserv/adventist_knapsack/issues/822