### PR TITLE
Clean up metadata issues

### DIFF
--- a/config/metadata/adl_metadata.yaml
+++ b/config/metadata/adl_metadata.yaml
@@ -66,6 +66,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - preflabel_tesi
     - preflabel_si
@@ -83,6 +84,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - rdfs_label_tesi
     predicate: http://www.w3.org/2000/01/rdf-schema#label
@@ -92,6 +94,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - date_tesim
     - date_sim
@@ -149,21 +152,17 @@ attributes:
       - "access_right_tesim"
     predicate: http://purl.org/dc/terms/accessRights
   # slugs previously used same predicate
+  # @TODO: removing index keys for now, until slug remediation script is complete.
   alternative_title:
     type: string
     multiple: true
     form:
       primary: false
-    index_keys:
-      - "alternative_title_sim"
-      - "alternative_title_tesim"
+      display: false
+    # index_keys:
+    #   - "alternative_title_sim"
+    #   - "alternative_title_tesim"
     predicate: http://purl.org/dc/terms/alternative
-  arkivo_checksum:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
   based_near:
     type: string
     multiple: true
@@ -206,6 +205,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
       - "date_created_sim"
       - "date_created_tesim"
@@ -252,8 +252,10 @@ attributes:
     predicate: http://purl.org/dc/elements/1.1/publisher
   label:
     type: string
+    multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
       - "label_sim"
       - "label_tesim"
@@ -365,26 +367,23 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     predicate: http://opaquenamespace.org/ns/hydra/owner
   on_behalf_of:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
-  state:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
   proxy_depositor:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -15,6 +15,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - date_tesim
     - date_sim
@@ -24,7 +25,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim
@@ -34,7 +35,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_published_tesim
     - date_published_sim
@@ -44,7 +45,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_submitted_tesim
     - date_submitted_sim
@@ -54,7 +55,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_accepted_tesim
     - date_accepted_sim
@@ -64,7 +65,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -108,7 +109,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - issue_number_tesim
     predicate: http://schema.org/issueNumber
@@ -168,6 +169,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - pagination_tesim
     predicate: http://schema.org/pagination
@@ -236,6 +238,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - preflabel_tesi
     - preflabel_si
@@ -253,6 +256,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - volume_number_tesim
     predicate: http://schema.org/volumeNumber
@@ -275,7 +279,6 @@ attributes:
       - "access_right_sim"
       - "access_right_tesim"
     predicate: http://purl.org/dc/terms/accessRights
-  # slugs previously used same predicate
   alternative_title:
     type: string
     multiple: true
@@ -285,12 +288,6 @@ attributes:
       - "alternative_title_sim"
       - "alternative_title_tesim"
     predicate: http://purl.org/dc/terms/alternative
-  arkivo_checksum:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
   based_near:
     type: string
     multiple: true
@@ -333,6 +330,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
       - "date_created_sim"
       - "date_created_tesim"
@@ -492,26 +490,23 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     predicate: http://opaquenamespace.org/ns/hydra/owner
   on_behalf_of:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
-  state:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
   proxy_depositor:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/conference_item_resource.yaml
+++ b/config/metadata/conference_item_resource.yaml
@@ -27,7 +27,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_published_tesim
     - date_published_sim
@@ -46,7 +46,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim
@@ -56,7 +56,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_submitted_tesim
     - date_submitted_sim
@@ -66,7 +66,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_accepted_tesim
     - date_accepted_sim
@@ -85,7 +85,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - event_date_tesim
     - event_date_sim
@@ -111,6 +111,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - pagination_tesim
     predicate: http://schema.org/pagination

--- a/config/metadata/dataset_resource.yaml
+++ b/config/metadata/dataset_resource.yaml
@@ -27,7 +27,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_published_tesim
     - date_published_sim
@@ -45,7 +45,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_collected_tesim
     - date_collected_sim
@@ -55,7 +55,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -85,20 +85,12 @@ attributes:
     index_keys:
     - extent_tesim
     predicate: http://purl.org/dc/terms/extent
-  dc_access_rights:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-    - dc_access_rights_tesim
-    predicate: http://purl.org/dc/terms/accessRights
   date_accepted:
     type: string
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_accepted_tesim
     - date_accepted_sim
@@ -127,7 +119,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim
@@ -137,7 +129,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_submitted_tesim
     - date_submitted_sim
@@ -151,7 +143,7 @@ attributes:
     - for_indexing_tesim
     predicate: http://dlib.york.ac.uk/ontologies/generic#forIndexing
   has_restriction:
-    type: date_time
+    type: string
     multiple: true
     form:
       primary: false
@@ -163,7 +155,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_valid_tesim
     - date_valid_sim
@@ -173,6 +165,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - number_of_downloads_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#numberOfDownloads
@@ -181,6 +174,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - readme_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#readme
@@ -206,7 +200,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_updated_tesim
     - date_updated_sim
@@ -216,6 +210,7 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - last_access_tesi
     predicate: http://dlib.york.ac.uk/ontologies/generic#lastAccess

--- a/config/metadata/exam_paper_resource.yaml
+++ b/config/metadata/exam_paper_resource.yaml
@@ -62,7 +62,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim

--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -24,6 +24,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -83,21 +84,17 @@ attributes:
       - "access_right_tesim"
     predicate: http://purl.org/dc/terms/accessRights
   # slugs previously used same predicate
+  # @TODO: removing index keys for now, until slug remediation script is complete.
   alternative_title:
     type: string
     multiple: true
     form:
       primary: false
-    index_keys:
-      - "alternative_title_sim"
-      - "alternative_title_tesim"
+      display: false
+    # index_keys:
+    #   - "alternative_title_sim"
+    #   - "alternative_title_tesim"
     predicate: http://purl.org/dc/terms/alternative
-  arkivo_checksum:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
   based_near:
     type: string
     multiple: true
@@ -140,6 +137,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
       - "date_created_sim"
       - "date_created_tesim"
@@ -186,8 +184,10 @@ attributes:
     predicate: http://purl.org/dc/elements/1.1/publisher
   label:
     type: string
+    multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
       - "label_sim"
       - "label_tesim"
@@ -299,26 +299,24 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     predicate: http://opaquenamespace.org/ns/hydra/owner
   on_behalf_of:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
-  state:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
+
   proxy_depositor:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/image_resource.yaml
+++ b/config/metadata/image_resource.yaml
@@ -24,6 +24,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -91,21 +92,17 @@ attributes:
       - "access_right_tesim"
     predicate: http://purl.org/dc/terms/accessRights
   # slugs previously used same predicate
+  # @TODO: removing index keys for now, until slug remediation script is complete.
   alternative_title:
     type: string
     multiple: true
     form:
       primary: false
-    index_keys:
-      - "alternative_title_sim"
-      - "alternative_title_tesim"
+      display: false
+    # index_keys:
+    #   - "alternative_title_sim"
+    #   - "alternative_title_tesim"
     predicate: http://purl.org/dc/terms/alternative
-  arkivo_checksum:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
   based_near:
     type: string
     multiple: true
@@ -148,6 +145,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
       - "date_created_sim"
       - "date_created_tesim"
@@ -194,8 +192,10 @@ attributes:
     predicate: http://purl.org/dc/elements/1.1/publisher
   label:
     type: string
+    multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
       - "label_sim"
       - "label_tesim"
@@ -307,26 +307,23 @@ attributes:
     multiple: false
     form:
       primary: false
+      multiple: false
     predicate: http://opaquenamespace.org/ns/hydra/owner
   on_behalf_of:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - on_behalf_of_ssi
     predicate: http://scholarsphere.psu.edu/ns#onBehalfOf
-  state:
-    type: string
-    multiple: false
-    form:
-      primary: false
-    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
   proxy_depositor:
     type: string
     multiple: false
     form:
       primary: false
+      multiple: false
     index_keys:
     - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor

--- a/config/metadata/journal_article_resource.yaml
+++ b/config/metadata/journal_article_resource.yaml
@@ -27,7 +27,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_published_tesim
     - date_published_sim
@@ -37,7 +37,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -72,7 +72,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim
@@ -82,7 +82,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_submitted_tesim
     - date_submitted_sim
@@ -92,7 +92,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_accepted_tesim
     - date_accepted_sim
@@ -138,7 +138,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - issue_number_tesim
     predicate: http://schema.org/issueNumber
@@ -155,6 +155,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - pagination_tesim
     predicate: http://schema.org/pagination
@@ -163,6 +164,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - volume_number_tesim
     predicate: http://schema.org/volumeNumber

--- a/config/metadata/published_work_resource.yaml
+++ b/config/metadata/published_work_resource.yaml
@@ -27,7 +27,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_published_tesim
     - date_published_sim
@@ -37,7 +37,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -72,7 +72,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_available_tesim
     - date_available_sim
@@ -82,7 +82,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_submitted_tesim
     - date_submitted_sim
@@ -92,7 +92,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - issue_number_tesim
     predicate: http://schema.org/issueNumber
@@ -117,6 +117,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - pagination_tesim
     predicate: http://schema.org/pagination
@@ -133,7 +134,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_accepted_tesim
     - date_accepted_sim
@@ -170,6 +171,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - volume_number_tesim
     predicate: http://schema.org/volumeNumber

--- a/config/metadata/thesis_resource.yaml
+++ b/config/metadata/thesis_resource.yaml
@@ -27,7 +27,7 @@ attributes:
     multiple: true
     form:
       primary: false
-      multiple: true
+      multiple: false
     index_keys:
     - date_issued_tesim
     - date_issued_sim
@@ -96,6 +96,7 @@ attributes:
     multiple: true
     form:
       primary: false
+      multiple: false
     index_keys:
     - date_of_award_tesim
     - date_of_award_sim


### PR DESCRIPTION
# Story

Metadata yaml files were audited and edited to:
- Change dates to be single rather than multiple
- Add multiple: false on form when term is not multiple... form defaults to multiple and term defaults to singular.
- Remove unnecessary state & arkivo_checksum
- remove dc_access_rights, which shares the same predicate in fedora with access_rights. (the shared predicate means they do the same thing, and the term is not accessed except in indexing.)

Refs

- https://github.com/scientist-softserv/adventist_knapsack/issues/777
- https://github.com/scientist-softserv/adventist_knapsack/issues/822

# Expected Behavior Before Changes

Many works types could be created but not edited.
Metadata single or multiple on form did not match production.

# Expected Behavior After Changes

- All work types and collection can be created.
- All work types and collection can be edited.
- All fields [with the exception of based_near location dropdown](https://github.com/scientist-softserv/adventist_knapsack/issues/212) can be used. 

# Screenshots / Video

<details>
<summary></summary>

**All work types and collection were tested, and can be both created and edited.**

![Screenshot 2024-09-30 at 4 09 38 PM](https://github.com/user-attachments/assets/69cd75bc-7323-48e6-9a16-a17b6f6eab56)

</details>

# Notes

OER and ETD do not currently work. These come in via Hyku and are not used in Adventist, so they have not been adequately set up. At this point, they should be deactivated in all tenants to avoid any potential issues.