### PR TITLE
Viewer fails for older files

### DIFF
--- a/lib/iiif_manifest/manifest_builder/canvas_builder_factory_decorator.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder_factory_decorator.rb
@@ -8,10 +8,19 @@ module IIIFManifest
       def from(work)
         composite_builder.new(
           *file_set_presenters(work).map do |presenter|
-            next if presenter.solr_document['original_filename_ssi'].downcase.end_with?(HykuKnapsack::Engine::THUMBNAIL_FILE_SUFFIX) || !presenter.image?
+            next if thumbnail?(presenter) || !presenter.image?
             canvas_builder_factory.new(presenter, work)
           end
         )
+      end
+
+      private
+
+      # older filesets may not have original_filename_ssi indexed so fallback to label_ssi
+      def thumbnail?(presenter)
+        filename = presenter.solr_document['original_filename_ssi'] || presenter.solr_document['label_ssi']
+        return false unless filename
+        filename.end_with?(HykuKnapsack::Engine::THUMBNAIL_FILE_SUFFIX)
       end
     end
   end


### PR DESCRIPTION
# Story

Expected term isn't always indexed. Adding a fallback to a different term to find file name.

Refs

- https://github.com/scientist-softserv/adventist_knapsack/issues/838

# Expected Behavior Before Changes

Older filesets without `original_filename_ssi` indexed show a black box for the universal viewer.

# Expected Behavior After Changes

Universal viewer displays images.

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
