### PR TITLE
Fix "more>>" modal popup on facets

### DIFF
--- a/app/views/themes/adventist_digital_library/layouts/hyrax.html.erb
+++ b/app/views/themes/adventist_digital_library/layouts/hyrax.html.erb
@@ -49,7 +49,6 @@
 
     </div><!-- /#content-wrapper -->
     <%= render partial: 'shared/footer' %>
-    <%# TODO: Do we still need this? Where is ajax_modal supposed to come from? %>
-    <%#= render 'shared/ajax_modal' %>
+    <%= render 'shared/modal' %>
   </body>
 </html>


### PR DESCRIPTION
# Story

Ref https://github.com/scientist-softserv/adventist_knapsack/issues/841

Add link to shared/modal in the layout for the adl theme.

# Expected Behavior Before Changes

Nothing happens when clicking "more>>" on the facets list.

# Expected Behavior After Changes

Modal opens correctly.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2024-10-07 at 6 43 37 PM](https://github.com/user-attachments/assets/05893336-5e91-4739-8c4d-880a4ce27c63)

</details>

# Notes
