### PR TITLE
Update Hyku to bring in snippets fixes

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -46,6 +46,7 @@ CatalogController.configure_blacklight do |config|
   # see: https://github.com/scientist-softserv/adventist-dl/blob/97bd05946345926b2b6c706bd90e183a9d78e8ef/app/controllers/catalog_controller.rb#L38-L40
   config.index_fields.keys.each do |key|
     next if key == 'all_text_timv'
+    next if key == 'all_text_tsimv'
     next if key == 'file_set_text_tsimv'
 
     config.index_fields.delete(key)
@@ -62,13 +63,6 @@ CatalogController.configure_blacklight do |config|
     { prop => CatalogController.send(:index_options, prop, DogBiscuits.config.property_mappings[prop]) }
   end
   CatalogController.send(:add_index_field, config, index_props)
-  # this is identical to what is in Hyku but the dog biscuits code seems to mean it doesn't carry through
-  config.add_index_field 'all_text_tsimv',
-  label: "Item contents",
-  highlight: true,
-  helper_method: :render_ocr_snippets,
-  values: ->(field_config, document, _context) { document.highlight_field(field_config.field).map(&:html_safe) if document.has_highlight_field? field_config.field }
-
   config.add_index_field 'based_near_label_tesim', itemprop: 'contentLocation', link_to_facet: 'based_near_label_sim'
 
   config.search_fields.delete('all_fields')

--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -62,7 +62,13 @@ CatalogController.configure_blacklight do |config|
     { prop => CatalogController.send(:index_options, prop, DogBiscuits.config.property_mappings[prop]) }
   end
   CatalogController.send(:add_index_field, config, index_props)
-  config.add_index_field 'all_text_tsimv', label: "Item contents", highlight: true, helper_method: :render_ocr_snippets, if: :query_present?
+  # this is identical to what is in Hyku but the dog biscuits code seems to mean it doesn't carry through
+  config.add_index_field 'all_text_tsimv',
+  label: "Item contents",
+  highlight: true,
+  helper_method: :render_ocr_snippets,
+  values: ->(field_config, document, _context) { document.highlight_field(field_config.field).map(&:html_safe) if document.has_highlight_field? field_config.field }
+
   config.add_index_field 'based_near_label_tesim', itemprop: 'contentLocation', link_to_facet: 'based_near_label_sim'
 
   config.search_fields.delete('all_fields')
@@ -74,7 +80,7 @@ CatalogController.configure_blacklight do |config|
                  DogBiscuits.config.all_properties.map { |p| "#{p}_tesim" }).uniq.join(" ")
     title_name = 'title_tesim'
     field.solr_parameters = {
-      qf: "#{all_names} file_format_tesim all_text_timv",
+      qf: "#{all_names} file_format_tesim all_text_timv all_text_tsimv",
       pf: title_name.to_s
     }
   end

--- a/app/helpers/hyku_knapsack/application_helper.rb
+++ b/app/helpers/hyku_knapsack/application_helper.rb
@@ -15,25 +15,6 @@ module HykuKnapsack
     def video_embed_viewer_display_partial(work_presenter)
       'hyrax/base/' + work_presenter.video_embed_viewer.to_s
     end
-
-    ##
-    # This is in place to coerce the :q string to :query for passing the :q value to the query value
-    # of a IIIF Print manifest.
-    #
-    # @param doc [SolrDocument]
-    # @param request [ActionDispatch::Request]
-    def generate_work_url(doc, request)
-      url = super
-      return url if request.params[:q].blank?
-
-      key = doc.any_highlighting? ? 'parent_query' : 'query'
-      query = { key => request.params[:q] }.to_query
-      if url.include?("?")
-        url + "&#{query}"
-      else
-        url + "?#{query}"
-      end
-    end
   end
 
   # A Blacklight index field helper_method

--- a/spec/helpers/hyku_knapsack/application_helper_spec.rb
+++ b/spec/helpers/hyku_knapsack/application_helper_spec.rb
@@ -21,24 +21,4 @@ RSpec.describe HykuKnapsack::ApplicationHelper do
   before do
     allow(helper).to receive(:current_account) { account }
   end
-
-  describe '#generate_work_url' do
-    context 'when params has a "q" parameter' do
-      let(:q) { "wonka-vision" }
-
-      context 'when any_highlighting? is false' do
-        it 'passes that along as :query' do
-          expect(doc).to receive(:any_highlighting?).and_return(false)
-          expect(helper.generate_work_url(doc, request)).to end_with("?query=#{q}")
-        end
-      end
-
-      context 'when any_highlighting? is true' do
-        it 'passes that along as :parent_query' do
-          expect(doc).to receive(:any_highlighting?).and_return(true)
-          expect(helper.generate_work_url(doc, request)).to end_with("?parent_query=#{q}")
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
# Story

Refs

- https://github.com/scientist-softserv/adventist_knapsack/issues/769

# Expected Behavior Before Changes

Snippets didn't work correctly

# Expected Behavior After Changes

- [ ] Search on catalog page performs full text search and shows highlighted snippets.
- [ ] Title and thumbnail urls carry the search terms through to the show pages and perform UV search automatically
- [ ] Search with no highlighting opens show page normally.

# Screenshots / Video

<details>
<summary></summary>

### Search on catalog page picks up terms in both full text and other metadata 
![Screenshot 2024-10-25 at 5 30 51 PM](https://github.com/user-attachments/assets/717d5b0b-92d8-4573-8408-825d7305e86d)
### clicking on work automatically searches the UV
![Screenshot 2024-10-25 at 5 31 17 PM](https://github.com/user-attachments/assets/d1963379-041e-4a35-bf5b-169782044634)

</details>

# Notes
