### PR TITLE
Re-define custom queries

### DIFF
--- a/config/initializers/pre_wings.rb
+++ b/config/initializers/pre_wings.rb
@@ -1,3 +1,14 @@
 Rails.application.config.to_prepare do
   WINGS_CONCERNS = [AdminSet, Collection, ConferenceItem, Dataset, Etd, ExamPaper, GenericWork, Image, JournalArticle, Oer, PublishedWork, Thesis].freeze
 end
+
+Rails.application.config.after_initialize do
+  Valkyrie::MetadataAdapter.register(
+    Freyja::MetadataAdapter.new,
+    :freyja
+  )
+  Valkyrie.config.metadata_adapter = :freyja
+
+  Hyrax.query_service.services[0].custom_queries.register_query_handler(Hyrax::CustomQueries::FindBySlug)
+  Hyrax.query_service.services[1].custom_queries.register_query_handler(Wings::CustomQueries::FindBySlug)
+end


### PR DESCRIPTION
# Story

Re-define custom queries needed for slugs.
Definition was removed in https://github.com/scientist-softserv/adventist_knapsack/pull/859

# Expected Behavior Before Changes

App crashed trying to load catalog page, with `find_with_slug` undefined.

# Expected Behavior After Changes

Able to create, view, and delete works with slugs.

# Screenshots / Video

<details>
<summary>Newly created work with slug</summary>

![Screenshot 2024-11-07 at 4 10 06 PM](https://github.com/user-attachments/assets/70ce8b1a-3ecd-4862-95af-b86f1ca3d82c)

![Screenshot 2024-11-07 at 4 11 57 PM](https://github.com/user-attachments/assets/5a19cb03-e8fa-48bc-a0e9-e4fc03ca54e5)


</details>

# Notes
