### PR TITLE
Ensure that viewers show rather than thumbnails

### DIFF
--- a/app/helpers/pdf_js_helper_decorator.rb
+++ b/app/helpers/pdf_js_helper_decorator.rb
@@ -33,8 +33,8 @@ module PdfJsHelperDecorator
   end
 
   def pdf_file_set_presenters(presenters)
-    presenters.select(&:pdf?).presence || presenters.select do |file_set_presenter|
-      file_set_presenter.solr_document["label_ssi"].downcase.end_with? ".pdf"
+    presenters.select(&:pdf?).presence || presenters.select do |fsp|
+      (fsp.solr_document['original_filename_tesi'] || fsp.solr_document['label_ssi'])&.downcase&.end_with?('.pdf')
     end
   end
 


### PR DESCRIPTION
# Story

Refs:
- #880 
- #881 

In the case of a split work, :pdf? needs to be included in the methods checked on a presenter.
In the case of a work that isn't split, Valkyrie has changed the term we use to check for a `.pdf` suffix. It appears that we do not fill in the label term. If characterization fails and we fall back to looking for a pdf, we needed to look in the right location.

# Expected Behavior Before Changes

When PDF.js is selected via flipper and a work has been split, it sometimes just shows a thumbnail.
When PDF.js is selected via flipper and work is not split, it sometimes just shows a thumbnail.

# Expected Behavior After Changes

In new (valkyrie) resources, resources converted from Fedora, and works still in Fedora:

- When PDF.js is selected via flipper and a work has been split, it shows the UV
- When PDF.js is selected via flipper and a work is not split, it shows the PDF in PDF.js

# Screenshots / Video

<details>
<summary>Both of these originally showed thumbnails only</summary>

![Screenshot 2024-11-13 at 2 51 37 PM](https://github.com/user-attachments/assets/0dbc51c1-a365-4b1a-a79d-3ce33d9d718d)


![Screenshot 2024-11-13 at 2 47 01 PM](https://github.com/user-attachments/assets/43050ab0-1783-4136-bd53-321cff20efc9)

</details>

# Notes
