### PR TITLE
Update decorator to accept file_set_params

### DIFF
--- a/app/services/hyrax/work_uploads_handler_decorator.rb
+++ b/app/services/hyrax/work_uploads_handler_decorator.rb
@@ -9,14 +9,14 @@ module Hyrax
     # @api private
     #
     # @return [Hash{Symbol => Object}]
-    def file_set_args(file)
+    def file_set_args(file, file_set_params = {})
       { depositor: file.user.user_key,
         creator: file.user.user_key,
         date_uploaded: file.created_at,
         date_modified: Hyrax::TimeService.time_in_utc,
         label: file.uploader.filename,
         title: file.uploader.filename,
-        override_default_thumbnail: file_set_extra_params(file)["override_default_thumbnail"] }
+        override_default_thumbnail: file_set_extra_params(file)["override_default_thumbnail"] }.merge(file_set_params)
     end
   end
 end


### PR DESCRIPTION
# Story

Hyrax was updated to allow passing additional parameters when creating FileSets, so we need to add the parameter to the decorator here.

Refs https://github.com/notch8/adventist_knapsack/issues/1025

# Expected Behavior Before Changes

Bulkrax imports broke

<img width="2704" height="1460" alt="image (10)" src="https://github.com/user-attachments/assets/b8b4a0bc-6480-4df3-87b9-aec5a638c06a" />

# Expected Behavior After Changes

Bulkrax imports complete for issue linked above.

# Screenshots / Video

# Notes
