### PR TITLE
move-to-s2-b2-nad-cloud

### DIFF
--- a/provision/vars/main.yml
+++ b/provision/vars/main.yml
@@ -12,13 +12,13 @@ git_repo_url: "https://orangewolf:{{ ghcr_token | urlencode }}@github.com/notch8
 
 environments:
   staging:
-    hyku_admin_host: s3.adventistdigitallibrary.org
+    hyku_admin_host: s2.adventistdigitallibrary.org
     hostnames:
-      - s3.adventistdigitallibrary.org
-      - '*.s3.adventistdigitallibrary.org'
+      - s2.adventistdigitallibrary.org
+      - '*.s2.adventistdigitallibrary.org'
     web_root: /store/keep/adventist_knapsack/public
-    ssl_cert_dest: /etc/letsencrypt/archive/s3.adventistdigitallibrary.org/fullchain1.pem
-    ssl_key_dest: /etc/letsencrypt/archive/s3.adventistdigitallibrary.org/privkey1.pem
+    ssl_cert_dest: /etc/letsencrypt/archive/s2.adventistdigitallibrary.org/fullchain1.pem
+    ssl_key_dest: /etc/letsencrypt/archive/s2.adventistdigitallibrary.org/privkey1.pem
     upstream_app_host: 192.168.147.200
     upstream_app_port: 3000
     # To get the UUID for each volume on the server run: lsblk -o NAME,UUID,MOUNTPOINT,FSTYPE
@@ -33,13 +33,13 @@ environments:
     - { path: "/store/keep/zoo_data",        uuid: "b1c16f24-6b47-4735-b085-106083f5fbe7", fstype: "xfs" }
 
   production:
-    hyku_admin_host: b3.adventistdigitallibrary.org
+    hyku_admin_host: b2.adventistdigitallibrary.org
     hostnames:
-      - b3.adventistdigitallibrary.org
-      - '*.b3.adventistdigitallibrary.org'
+      - b2.adventistdigitallibrary.org
+      - '*.b2.adventistdigitallibrary.org'
     web_root: /store/keep/adventist_knapsack/public
-    ssl_cert_dest: /etc/letsencrypt/archive/b3.adventistdigitallibrary.org/fullchain1.pem
-    ssl_key_dest: /etc/letsencrypt/archive/b3.adventistdigitallibrary.org/privkey1.pem
+    ssl_cert_dest: /etc/letsencrypt/archive/b2.adventistdigitallibrary.org/fullchain1.pem
+    ssl_key_dest: /etc/letsencrypt/archive/b2.adventistdigitallibrary.org/privkey1.pem
     upstream_app_host: 192.168.147.100
     upstream_app_port: 3000
     # To get the UUID for each volume on the server run: lsblk -o NAME,UUID,MOUNTPOINT,FSTYPE


### PR DESCRIPTION
## Update main.yml to deploy to Nadcloud using new s2/b2 domain naming convention

### Pre-Deployment Note
Before running this deploy, the new domain(s) **must be added to each existing Hyku tenant** as additional allowed domains.  
This ensures that tenants currently accessible via the old domains continue to function and can be accessed via the new `s2/b2` domains once the deployment completes.

### Story
Now that the client’s legacy AWS Hyku site has been decommissioned, we’re swapping the Nadcloud deployment domains from the previous `s3/b3` naming convention to `s2/b2`. This ensures Nadcloud environments are deployed on the correct hostnames and receive TLS certificates automatically as part of the existing Ansible + certbot workflow.

### Refs
- # https://github.com/notch8/adventist_knapsack/issues/1034

### What Changed
Updated `main.yml` to replace the legacy Nadcloud domains:

- `s3.adventistdigitallibrary.org`
- `b3.adventistdigitallibrary.org`

New deployments now use:

- `s2.adventistdigitallibrary.org`
- `b2.adventistdigitallibrary.org`

Domain changes are picked up by Ansible and used during certbot certificate issuance.

### Expected Behavior Before Changes
Deployments reference the old Nadcloud domains:

- `s3.adventistdigitallibrary.org`
- `b3.adventistdigitallibrary.org`

TLS certificates (where present) are issued for the old hostnames.

### Expected Behavior After Changes
Deployments reference the new Nadcloud domains:

- `s2.adventistdigitallibrary.org`
- `b2.adventistdigitallibrary.org`

On deployment, environments are created/updated using the new domains.

Certbot automatically issues/renews certificates for `s2.adventistdigitallibrary.org` and `b2.adventistdigitallibrary.org` as part of the Ansible deploy.